### PR TITLE
Unity SDK contract update

### DIFF
--- a/contracts/Content/Content.sol
+++ b/contracts/Content/Content.sol
@@ -14,7 +14,7 @@ contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165Sto
     /******************** Constants ********************/
     /*
      * ERC1155 interface == 0xd9b67a26
-     * IContent == 0x15f57ea0
+     * IContent == 0x6a3af2b5
      * IContractUri == 0xc0e24d5e
      * IERC2981Upgradeable == 0x2a55205a
      */

--- a/contracts/Content/Content.sol
+++ b/contracts/Content/Content.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import "./interfaces/IContent.sol";
 import "./interfaces/IAccessControlManager.sol";
 import "./interfaces/IContentStorage.sol";
+import "hardhat/console.sol";
 
 contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165StorageUpgradeable {
     /******************** Constants ********************/
@@ -105,8 +106,8 @@ contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165Sto
         return contentStorage.getContractRoyalty();
     }
     
-    function userMintNonce() external view override returns (uint256) {
-        return accessControlManager.userMintNonce(_msgSender());
+    function userMintNonce(address _user) external view override returns (uint256) {
+        return accessControlManager.userMintNonce(_user);
     }
     
     function royaltyInfo(uint256 _tokenId, uint256 _salePrice) external view override returns (address receiver, uint256 royaltyAmount) {

--- a/contracts/Content/interfaces/IContent.sol
+++ b/contracts/Content/interfaces/IContent.sol
@@ -22,7 +22,7 @@ interface IContent is IContractUri, IERC1155Upgradeable {
 
     function contractRoyalty() external view returns (address receiver, uint24 rate);
     
-    function userMintNonce() external view returns (uint256);
+    function userMintNonce(address _user) external view returns (uint256);
 
     /******** Mutative Functions ********/
 

--- a/test/content/ContentTests.js
+++ b/test/content/ContentTests.js
@@ -51,7 +51,7 @@ describe('Content Contract Tests', () => {
             expect(await content.supportsInterface("0xd9b67a26")).to.equal(true);
 
             // IContent Interface
-            expect(await content.supportsInterface("0x15f57ea0")).to.equal(true);
+            expect(await content.supportsInterface("0x6a3af2b5")).to.equal(true);
 
             // IContractUri Interface
             expect(await content.supportsInterface("0xc0e24d5e")).to.equal(true);


### PR DESCRIPTION
In this PR:
- Update userMintNonce() in Content Contract to pass the user address instead of using _msgSender()
- Update tests for new IContent interface