### PR TITLE
Exchange - Add Max Spend for Fill Order 

### DIFF
--- a/contracts/exchange/Orderbook.sol
+++ b/contracts/exchange/Orderbook.sol
@@ -129,7 +129,12 @@ contract Orderbook is IOrderbook, ManagerBase {
         return true;
     }
 
-    function getOrderAmounts(uint256[] calldata _orderIds) external view override returns(uint256[] memory orderAmounts) {
+    function getOrderAmounts(
+        uint256[] memory _orderIds,
+        uint256 amountToFill,
+        uint256 maxSpend
+    ) external view override returns(uint256[] memory orderAmounts, uint256 amountFilled) {
+        // Get Available Orders
         orderAmounts = new uint256[](_orderIds.length); // default already at 0
         for (uint256 i = 0; i < _orderIds.length; ++i) {
             if (orders[_orderIds[i]].state == LibOrder.OrderState.READY) {
@@ -137,6 +142,40 @@ contract Orderbook is IOrderbook, ManagerBase {
                 orderAmounts[i] = orders[_orderIds[i]].amountOrdered;
             } else if (orders[_orderIds[i]].state == LibOrder.OrderState.PARTIALLY_FILLED) {
                 orderAmounts[i] = orders[_orderIds[i]].amountOrdered - orders[_orderIds[i]].amountFilled;
+            }
+        }
+
+        // get amounts ordered based on AmountToFill and Max Spend
+        amountFilled = 0;
+        uint256 amountSpentOnOrder = 0;
+        for (uint256 i = 0; i < orderAmounts.length; ++i) {
+            if (orderAmounts[i] > 0) {
+                amountSpentOnOrder = orders[_orderIds[i]].price * orderAmounts[i];
+                
+                // Check if there's you're still under tha max Spend
+                if (maxSpend == 0) {
+                    orderAmounts[i] = 0;
+                    continue;
+                } else if (maxSpend > amountSpentOnOrder) {
+                    maxSpend -= amountSpentOnOrder;
+                } else if (maxSpend < amountSpentOnOrder) {
+                    orderAmounts[i] = maxSpend / orders[_orderIds[i]].price;
+                    maxSpend = 0;
+                }
+
+                if (orderAmounts[i] <= amountToFill) {
+                    // order amount exists but is less than amount remaining to sell
+                    amountToFill -= orderAmounts[i];
+                    amountFilled += orderAmounts[i];
+                } else if (amountToFill > 0) {
+                    // order amount exists but is more than amount remaining to sell
+                    orderAmounts[i] = amountToFill;
+                    amountFilled += amountToFill; // remainder
+                    amountToFill = 0;
+                } else {
+                    // no more orders to sell
+                    orderAmounts[i] = 0;
+                }
             }
         }
     }

--- a/contracts/exchange/Orderbook.sol
+++ b/contracts/exchange/Orderbook.sol
@@ -152,11 +152,11 @@ contract Orderbook is IOrderbook, ManagerBase {
             if (orderAmounts[i] > 0) {
                 amountSpentOnOrder = orders[_orderIds[i]].price * orderAmounts[i];
                 
-                // Check if there's you're still under tha max Spend
+                // Check if the transaction is still under tha Max Spend
                 if (maxSpend == 0) {
                     orderAmounts[i] = 0;
                     continue;
-                } else if (maxSpend > amountSpentOnOrder) {
+                } else if (maxSpend >= amountSpentOnOrder) {
                     maxSpend -= amountSpentOnOrder;
                 } else if (maxSpend < amountSpentOnOrder) {
                     orderAmounts[i] = maxSpend / orders[_orderIds[i]].price;
@@ -164,11 +164,11 @@ contract Orderbook is IOrderbook, ManagerBase {
                 }
 
                 if (orderAmounts[i] <= amountToFill) {
-                    // order amount exists but is less than amount remaining to sell
+                    // order amount exists but is less than amount remaining to fill
                     amountToFill -= orderAmounts[i];
                     amountFilled += orderAmounts[i];
                 } else if (amountToFill > 0) {
-                    // order amount exists but is more than amount remaining to sell
+                    // order amount exists but is greater than amount remaining to fill
                     orderAmounts[i] = amountToFill;
                     amountFilled += amountToFill; // remainder
                     amountToFill = 0;

--- a/contracts/exchange/interfaces/IExchange.sol
+++ b/contracts/exchange/interfaces/IExchange.sol
@@ -20,12 +20,14 @@ interface IExchange {
     
     function fillBuyOrder(
         uint256[] memory _orderIds,
-        uint256 amountToBuy
+        uint256 amountToBuy,
+        uint256 maxSpend
     ) external;
 
     function fillSellOrder(
         uint256[] memory _orderIds,
-        uint256 amountToSell
+        uint256 amountToSell,
+        uint256 maxSpend
     ) external;
 
     function cancelOrders(uint256[] memory _orderIds) external;

--- a/contracts/exchange/interfaces/IExchange.sol
+++ b/contracts/exchange/interfaces/IExchange.sol
@@ -20,13 +20,13 @@ interface IExchange {
     
     function fillBuyOrder(
         uint256[] memory _orderIds,
-        uint256 amountToBuy,
+        uint256 amountToSell,
         uint256 maxSpend
     ) external;
 
     function fillSellOrder(
         uint256[] memory _orderIds,
-        uint256 amountToSell,
+        uint256 amountToBuy,
         uint256 maxSpend
     ) external;
 

--- a/contracts/exchange/interfaces/IOrderbook.sol
+++ b/contracts/exchange/interfaces/IOrderbook.sol
@@ -27,7 +27,7 @@ interface IOrderbook {
 
     function getOrderAmounts(
         uint256[] memory _orderIds,
-        uint256 amountToSell,
+        uint256 amountToFill,
         uint256 maxSpend
     ) external view returns(uint256[] memory orderAmounts, uint256 amountFilled);
 

--- a/contracts/exchange/interfaces/IOrderbook.sol
+++ b/contracts/exchange/interfaces/IOrderbook.sol
@@ -25,7 +25,11 @@ interface IOrderbook {
 
     function verifyOrdersReady(uint256[] memory _orderIds) external view returns (bool);
 
-    function getOrderAmounts(uint256[] memory _orderIds) external view returns(uint256[] memory orderAmounts);
+    function getOrderAmounts(
+        uint256[] memory _orderIds,
+        uint256 amountToSell,
+        uint256 maxSpend
+    ) external view returns(uint256[] memory orderAmounts, uint256 amountFilled);
 
     function getPaymentTotals(
         uint256[] calldata _orderIds,

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -132,7 +132,7 @@ describe('Exchange Contract', () => {
 
     it('Supports the Exchange Interface', async () => {
         // IExchange Interface
-        expect(await exchange.supportsInterface("0xdf858c9f")).to.equal(true);
+        expect(await exchange.supportsInterface("0x581b76ff")).to.equal(true);
     });
   });
 
@@ -255,7 +255,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
 
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1))
+      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // platform has 30 basis points and creator has 200 basis points from royalties so player2Address should only have
@@ -288,7 +288,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(1000).mul(_1e18));
 
-      expect(await exchange.connect(player2Address).fillSellOrder([orderId], 1))
+      expect(await exchange.connect(player2Address).fillSellOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // Player 2 originally has 10, but after buying 1 more, he should have 11
@@ -334,7 +334,7 @@ describe('Exchange Contract', () => {
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(400).mul(_1e18));
 
       // Player 2 buys 4 items from the 2 orders
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 4))
+      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 4, ethers.BigNumber.from(400).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id, order2Id], [2, 2], [content.address, 1], rawrToken.address, 4, ethers.BigNumber.from(400).mul(_1e18));
 
@@ -386,12 +386,12 @@ describe('Exchange Contract', () => {
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(400).mul(_1e18));
 
       // Fill Order 1 first
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id], 2))
+      expect(await exchange.connect(player2Address).fillSellOrder([order1Id], 2, ethers.BigNumber.from(100).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id], [1], [content.address, 1], rawrToken.address, 1, ethers.BigNumber.from(100).mul(_1e18));
 
       // // Player 2 buys 2 items from the 2 orders, ignoring order
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 3))
+      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 3, ethers.BigNumber.from(300).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id, order2Id], [0, 3], [content.address, 1], rawrToken.address, 3, ethers.BigNumber.from(300).mul(_1e18));
 
@@ -433,7 +433,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
 
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1))
+      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // Claim player 1's purchased asset
@@ -467,7 +467,7 @@ describe('Exchange Contract', () => {
 
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1))
+      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       expect(await rawrToken.balanceOf(player2Address.address)).to.equal(ethers.BigNumber.from(10977).mul(_1e18));


### PR DESCRIPTION
In order to account for possible slippage in orders, we include a "Max Spend" in the FillBuyOrder or FillSellOrder functions.

If an FillBuy/SellOrder transaction has orders that have been filled before the transaction is able to finish, it may end up slipping and increasing the amount of tokens spent. 

Order 1 - $10 for 3 assets
Order 2 - $20 for 3 assets

Fill Sell Order - 4 items

Ideally, it fills in 3 items from order 1 and 1 item from order 2 and spend $40. But if Order 1 gets filled before this transaction is executed, it may end up buying more items from Order 2 and spend $60 for 3 items instead.

#38 