### PR TITLE
Content Manager and Content Factory bug fixes

### DIFF
--- a/contracts/Content/ContentManager.sol
+++ b/contracts/Content/ContentManager.sol
@@ -104,14 +104,6 @@ contract ContentManager is IContentManager, OwnableUpgradeable, ERC165StorageUpg
     function setTokenRoyaltiesBatch(LibAsset.AssetRoyalties[] memory _assets) external override onlyOwner {
         contentStorage.setTokenRoyaltiesBatch(_assets);
     }
-    
-    /**
-    * @dev verifies if the user has the requisite permissions, if the token exists, and if the max supply has not been reached. It then * mints the asset and updates the supply.
-    * @param _data LibAsset.MintData structure object
-    */
-    function mintBatch(LibAsset.MintData memory _data) external override onlyOwner {
-        content.mintBatch(_data);
-    }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165StorageUpgradeable) returns (bool) {
         return super.supportsInterface(interfaceId);

--- a/contracts/Content/factory/ContentFactory.sol
+++ b/contracts/Content/factory/ContentFactory.sol
@@ -103,6 +103,7 @@ contract ContentFactory is ContextUpgradeable, OwnableUpgradeable {
         contentStorage.grantRole(contentStorage.DEFAULT_ADMIN_ROLE(), address(contentManager));
         contentStorage.setParent(address(content));
         accessControlManager.grantRole(accessControlManager.DEFAULT_ADMIN_ROLE(), address(contentManager));
+        accessControlManager.grantRole(accessControlManager.MINTER_ROLE(), _msgSender());
         accessControlManager.setParent(address(content));
         
         // transfer ownership to message sender

--- a/contracts/Content/interfaces/IContentManager.sol
+++ b/contracts/Content/interfaces/IContentManager.sol
@@ -27,6 +27,4 @@ interface IContentManager {
     function setContractRoyalty(address _receiver, uint24 _rate) external;
     
     function setTokenRoyaltiesBatch(LibAsset.AssetRoyalties[] memory _assets) external;
-    
-    function mintBatch(LibAsset.MintData memory _data) external;
 }

--- a/test/content/ContentFactoryTests.js
+++ b/test/content/ContentFactoryTests.js
@@ -55,6 +55,11 @@ describe('Content Clone Factory Tests', () => {
             
             expect(await contentFactory.contentExists(content.address)).is.equal(true);
             expect(await contentFactory.contentManagerExists(contentManager.address)).is.equal(true);
+
+            // check if the developer wallet can mint
+            var accessControlManager = await AccessControlManager.attach(await contentManager.accessControlManager());
+            var minter_role = await accessControlManager.MINTER_ROLE();
+            expect(await accessControlManager.hasRole(minter_role, deployerAddress.address)).is.equal(true);
         });
         
         it('Create Content Contracts from different developers', async () => {

--- a/test/content/ContentManagerTests.js
+++ b/test/content/ContentManagerTests.js
@@ -54,7 +54,7 @@ describe('Content Manager Contract Tests', () => {
 
         it('Check Supported interfaces', async () => {
             // Content Manager interface
-            expect(await contentManager.supportsInterface("0x250b1d27")).to.equal(true);
+            expect(await contentManager.supportsInterface("0xa15f6002")).to.equal(true);
         });
     });
 
@@ -168,7 +168,7 @@ describe('Content Manager Contract Tests', () => {
             await content.connect(craftingSystemAddress).mintBatch(mintData);
             expect(await content.totalSupply(1)).to.equal(100);
 
-            await expect(content.connect(deployerAddress).mintBatch(mintData)).to.be.reverted;
+            await expect(content.connect(playerAddress).mintBatch(mintData)).to.be.reverted;
             expect(await content.totalSupply(1)).to.equal(100);
         });
     });

--- a/test/content/ContentManagerTests.js
+++ b/test/content/ContentManagerTests.js
@@ -167,9 +167,6 @@ describe('Content Manager Contract Tests', () => {
             
             await content.connect(craftingSystemAddress).mintBatch(mintData);
             expect(await content.totalSupply(1)).to.equal(100);
-
-            await expect(content.connect(playerAddress).mintBatch(mintData)).to.be.reverted;
-            expect(await content.totalSupply(1)).to.equal(100);
         });
     });
 });

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -68,10 +68,10 @@ describe('Exchange Contract', () => {
 
     // Mint an asset
     var mintData = [playerAddress.address, [1, 2], [10, 1], 0, ethers.constants.AddressZero, []];
-    await contentManager.mintBatch(mintData);
+    await content.connect(deployerAddress).mintBatch(mintData);
 
     mintData = [player2Address.address, [1, 2], [10, 10], 0, ethers.constants.AddressZero, []];
-    await contentManager.mintBatch(mintData);
+    await content.connect(deployerAddress).mintBatch(mintData);
   }
 
   async function RawrTokenSetup() {

--- a/test/exchange/ExecutionManagerTests.js
+++ b/test/exchange/ExecutionManagerTests.js
@@ -66,10 +66,10 @@ describe('Execution Manager Contract Tests', ()=> {
         
         // Mint an asset
         var mintData = [playerAddress.address, [1], [10], 0, ethers.constants.AddressZero, []];
-        await contentManager.mintBatch(mintData);
+        await content.connect(deployerAddress).mintBatch(mintData);
         
         mintData = [player2Address.address, [2], [5], 0, ethers.constants.AddressZero, []];
-        await contentManager.mintBatch(mintData);
+        await content.connect(deployerAddress).mintBatch(mintData);
     }
 
     async function RawrTokenSetup() {

--- a/test/exchange/NftEscrowTests.js
+++ b/test/exchange/NftEscrowTests.js
@@ -56,7 +56,7 @@ describe('NFT Escrow Contract', () => {
 
         // Mint an assets
         var mintData = [playerAddress.address, [1, 2], [10, 1], 0, ethers.constants.AddressZero, []];
-        await contentManager.mintBatch(mintData);
+        await content.connect(deployerAddress).mintBatch(mintData);
 
         assetData = [content.address, 1];
 


### PR DESCRIPTION
Bugs Fixed:
- Content Manager shouldn't have a mintBatch(), this is causing the subgraph a fatal error because the "Mint address" becomes the content manager address instead of the developer address. The subgraph is not expecting this. Subgraph also needs a fix.
- Content Factory doesn't automatically give the developer wallet mint access on the Content contract. 
- Update a few tests