### PR TITLE
[Optimization] Content AddAssetBatch automatically generate token id

### DIFF
--- a/contracts/Content/Content.sol
+++ b/contracts/Content/Content.sol
@@ -176,7 +176,7 @@ contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165Sto
     }
 
     function _tokenExists(uint256 _tokenId) internal view returns(bool) {
-        return contentStorage.ids(_tokenId);
+        return _tokenId < contentStorage.assetCounter();
     }
 
     function _updateSupply(uint256 _tokenId, uint256 _newSupply) internal {

--- a/contracts/Content/ContentManager.sol
+++ b/contracts/Content/ContentManager.sol
@@ -35,7 +35,6 @@ contract ContentManager is IContentManager, OwnableUpgradeable, ERC165StorageUpg
         __ERC165Storage_init_unchained();
         __ContentManager_init_unchained(_content, _contentStorage, _accessControlManager);
     }
-    
 
     function __ContentManager_init_unchained(
         address _content,

--- a/contracts/Content/ContentStorage.sol
+++ b/contracts/Content/ContentStorage.sol
@@ -19,9 +19,9 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
      */
 
     /***************** Stored Variables *****************/
-    mapping(uint256 => bool) public override ids;
     mapping(uint256 => uint256) public override maxSupply;
     mapping(uint256 => uint256) public override supply;
+    uint256 public override assetCounter;
 
     /******************** Public API ********************/
     function initialize(
@@ -41,7 +41,6 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
         _registerInterface(type(IContentStorage).interfaceId);
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     }
-
      
     /**
     * @dev assigns the address of contentParent and transfers role of DEFAULT_ADMIN_ROLE to the _contentParent parameter
@@ -61,25 +60,28 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     * @param _assets an array of LibAsset.CreateData structure objects
     */
     function addAssetBatch(LibAsset.CreateData[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256[] memory tokenIds = new uint256[](_assets.length);
         for (uint256 i = 0; i < _assets.length; ++i) {
-            require(!ids[_assets[i].tokenId], "Token Id already exists.");
-            ids[_assets[i].tokenId] = true;
-            supply[_assets[i].tokenId] = 0;
+            tokenIds[i] = assetCounter;
+            supply[assetCounter] = 0;
 
             // If max supply is set to 0, this means there is no mint limit. Set max supply to uint256.max
             if (_assets[i].maxSupply == 0) {
                 _assets[i].maxSupply = type(uint256).max; 
             } 
-            maxSupply[_assets[i].tokenId] = _assets[i].maxSupply;
+            maxSupply[assetCounter] = _assets[i].maxSupply;
 
-            _setPublicUri(_assets[i].tokenId, _assets[i].publicDataUri);
-            _setHiddenUri(_assets[i].tokenId, _assets[i].hiddenDataUri);
+            _setPublicUri(assetCounter, _assets[i].publicDataUri);
+            _setHiddenUri(assetCounter, _assets[i].hiddenDataUri);
             
             // if this specific token has a different royalty fees than the contract
-            _setTokenRoyalty(_assets[i].tokenId, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
+            _setTokenRoyalty(assetCounter, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
+
+            // increment asset counter
+            assetCounter++;
         }
 
-        emit AssetsAdded(_parent(), _assets);
+        emit AssetsAdded(_parent(), tokenIds, _assets);
     }
 
     /**
@@ -97,7 +99,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     */
     function setHiddenUriBatch(LibAsset.AssetUri[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         for (uint256 i = 0; i < _assets.length; ++i) {
-            require(ids[_assets[i].tokenId], "Invalid Token Id");
+            require(_assets[i].tokenId < assetCounter, "Invalid Token Id");
             _setHiddenUri(_assets[i].tokenId, _assets[i].uri);
         }
     }
@@ -108,7 +110,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     */
     function setPublicUriBatch(LibAsset.AssetUri[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         for (uint256 i = 0; i < _assets.length; ++i) {
-            require(ids[_assets[i].tokenId], "Invalid Token Id");
+            require(_assets[i].tokenId < assetCounter, "Invalid Token Id");
             _setPublicUri(_assets[i].tokenId, _assets[i].uri);
         }
     }
@@ -131,7 +133,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     function setTokenRoyaltiesBatch(LibAsset.AssetRoyalties[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         // This overwrites the existing array of contract fees.
         for (uint256 i = 0; i < _assets.length; ++i) {
-            require(ids[_assets[i].tokenId], "Invalid Token Id");
+            require(_assets[i].tokenId < assetCounter, "Invalid Token Id");
             _setTokenRoyalty(_assets[i].tokenId, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
         }
     }

--- a/contracts/Content/interfaces/IContentStorage.sol
+++ b/contracts/Content/interfaces/IContentStorage.sol
@@ -8,10 +8,10 @@ import "./IContractUri.sol";
 interface IContentStorage is IContractUri {
 
     /*********************** Events *********************/
-    event AssetsAdded(address indexed parent, LibAsset.CreateData[] assets);
+    event AssetsAdded(address indexed parent, uint256[] tokenIds, LibAsset.CreateData[] assets);
 
     /******** View Functions ********/
-    function ids(uint256 _tokenId) external view returns (bool);
+    function assetCounter() external view returns (uint256);
 
     function supply(uint256 _tokenId) external view returns (uint256);
 

--- a/contracts/libraries/LibAsset.sol
+++ b/contracts/libraries/LibAsset.sol
@@ -6,7 +6,6 @@ library LibAsset {
     bytes32 public constant MINT_DATA_TYPEHASH = keccak256("MintData(address to,uint256[] tokenIds,uint256[] amounts,uint256 nonce,address signer)");
         
     struct CreateData {
-        uint256 tokenId;
         string publicDataUri;
         string hiddenDataUri;
         uint256 maxSupply;

--- a/scripts/subgraph_arweave_data.js
+++ b/scripts/subgraph_arweave_data.js
@@ -21,12 +21,12 @@ async function deployContract(factory, developer, rate, uri) {
 
 async function addRawrshakAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/oYnTrb5bUIm1lgbTpBFZ9LLPVeDpDxb_vW1XBNfzlgI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
-        [1, "https://arweave.net/GFVxBPSj-bSQ_bi5ZIaxJV1fKm63pI0Dcc_qwMZIvg0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
-        [2, "https://arweave.net/y2b16LSQOqmjUeckSCltiH4_8XP3GVZVgps0N6eG6HI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
-        [3, "https://arweave.net/pIXtTejDqULTO16tOhcA5goEoeC8kMufmxZrpUkAZPA", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
-        [4, "https://arweave.net/BT067qgPxUoMQOogSvxPRIwwIwv-eKf7xb-rzeRWvSU", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
-        [5, "https://arweave.net/pOiwYzVm9_VVuVtdWqgaw57A1A9c3vdxeNG9d3cgZuM", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
+        ["https://arweave.net/oYnTrb5bUIm1lgbTpBFZ9LLPVeDpDxb_vW1XBNfzlgI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
+        ["https://arweave.net/GFVxBPSj-bSQ_bi5ZIaxJV1fKm63pI0Dcc_qwMZIvg0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
+        ["https://arweave.net/y2b16LSQOqmjUeckSCltiH4_8XP3GVZVgps0N6eG6HI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
+        ["https://arweave.net/pIXtTejDqULTO16tOhcA5goEoeC8kMufmxZrpUkAZPA", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
+        ["https://arweave.net/BT067qgPxUoMQOogSvxPRIwwIwv-eKf7xb-rzeRWvSU", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
+        ["https://arweave.net/pOiwYzVm9_VVuVtdWqgaw57A1A9c3vdxeNG9d3cgZuM", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
     ];
 
     // add assets
@@ -39,15 +39,15 @@ async function addRawrshakAssets(content, contentManager, developer) {
 
 async function addScreamFortress2Assets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/Rg_ldKekDpRydL52p0EQeG7LnCHAzd6_ehE59omkl38", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
-        [1, "https://arweave.net/Z90dMMhDYK5d9vP0LDMdDDd4lnwEXCwJjHcbXfdIySw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
-        [2, "https://arweave.net/xSQgeZmVwzQjWfad6AfrIWXPcvivMXXFa_GaynnvliY", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
-        [3, "https://arweave.net/QOu6LWgWwoOpSfKJC21Zc8HgRKdpamMLpgRciWLzcQw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
-        [4, "https://arweave.net/uJxDoYDITlNAH14tXIOP8he_AuGHZ5ZHW_XL342Laj0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
-        [5, "https://arweave.net/TmSZJve-3-Ckpa-zlWgksIT2A-dqDxdnxdUBitxB1Lw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
-        [6, "https://arweave.net/W3h0XvASvmYZfuX6JV1s2AHEoAbTXxSpEarjFLi65Nc", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
-        [7, "https://arweave.net/OFpQMdO9D9VNh0CYg3lfJNtOT_l3XpTAFq19-saDkJU", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
-        [8, "https://arweave.net/NS-yuTTqq_wCY5wVwdSv_cipRM5GgUirL8rN4jesDfg", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
+        ["https://arweave.net/Rg_ldKekDpRydL52p0EQeG7LnCHAzd6_ehE59omkl38", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
+        ["https://arweave.net/Z90dMMhDYK5d9vP0LDMdDDd4lnwEXCwJjHcbXfdIySw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
+        ["https://arweave.net/xSQgeZmVwzQjWfad6AfrIWXPcvivMXXFa_GaynnvliY", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
+        ["https://arweave.net/QOu6LWgWwoOpSfKJC21Zc8HgRKdpamMLpgRciWLzcQw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
+        ["https://arweave.net/uJxDoYDITlNAH14tXIOP8he_AuGHZ5ZHW_XL342Laj0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
+        ["https://arweave.net/TmSZJve-3-Ckpa-zlWgksIT2A-dqDxdnxdUBitxB1Lw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
+        ["https://arweave.net/W3h0XvASvmYZfuX6JV1s2AHEoAbTXxSpEarjFLi65Nc", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
+        ["https://arweave.net/OFpQMdO9D9VNh0CYg3lfJNtOT_l3XpTAFq19-saDkJU", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
+        ["https://arweave.net/NS-yuTTqq_wCY5wVwdSv_cipRM5GgUirL8rN4jesDfg", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
     ];
 
     // add assets
@@ -60,10 +60,10 @@ async function addScreamFortress2Assets(content, contentManager, developer) {
 
 async function addFightBuddyAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/cg2N77GOOcKriioxIwEeeW3mU-a4XlTa6GOt1BQixIE", "", 1000, developer.address, 10000],         // Nikolai
-        [1, "https://arweave.net/ULuMJ7q_8uomd-tG2FWb-n2ZnlX_4deteFGzsv1MzkY", "", 1000, developer.address, 20000],         // Didier
-        [2, "https://arweave.net/qT_Se_bUb-HVE3JIOVzNFLgKc3m0t5hmEhml7X1WWLg", "", 500, ethers.constants.AddressZero, 0],   // Josip
-        [3, "https://arweave.net/tWfM7C5a-mC1Q6mU76Ik62iE3jYsl9QrB9mgvTAwsm8", "", 50, developer.address, 30000]            // Glenn
+        ["https://arweave.net/cg2N77GOOcKriioxIwEeeW3mU-a4XlTa6GOt1BQixIE", "", 1000, developer.address, 10000],         // Nikolai
+        ["https://arweave.net/ULuMJ7q_8uomd-tG2FWb-n2ZnlX_4deteFGzsv1MzkY", "", 1000, developer.address, 20000],         // Didier
+        ["https://arweave.net/qT_Se_bUb-HVE3JIOVzNFLgKc3m0t5hmEhml7X1WWLg", "", 500, ethers.constants.AddressZero, 0],   // Josip
+        ["https://arweave.net/tWfM7C5a-mC1Q6mU76Ik62iE3jYsl9QrB9mgvTAwsm8", "", 50, developer.address, 30000]            // Glenn
     ];
 
     // add assets
@@ -76,10 +76,10 @@ async function addFightBuddyAssets(content, contentManager, developer) {
 
 async function addSuperScaryHorrorGameAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/lfLN2kypyClSFDXV_UbcDAr-IkNUNTHykCVx2uZueCg", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
-        [1, "https://arweave.net/CtIZH6MptmKwZJ0h1QgRYZ3LxTmYRn52dHOkdn5OQyc", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
-        [2, "https://arweave.net/62GxTC26d3ZuD67hXHWFSCbyIfgw6bRIkavumyRGt9M", "", 50, ethers.constants.AddressZero, 0],    // Screamer
-        [3, "https://arweave.net/dCI3wOGGNXQb_WzwsNik7gzKQ5YDZFp_Q_Fqvw0aYI8", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
+        ["https://arweave.net/lfLN2kypyClSFDXV_UbcDAr-IkNUNTHykCVx2uZueCg", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
+        ["https://arweave.net/CtIZH6MptmKwZJ0h1QgRYZ3LxTmYRn52dHOkdn5OQyc", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
+        ["https://arweave.net/62GxTC26d3ZuD67hXHWFSCbyIfgw6bRIkavumyRGt9M", "", 50, ethers.constants.AddressZero, 0],    // Screamer
+        ["https://arweave.net/dCI3wOGGNXQb_WzwsNik7gzKQ5YDZFp_Q_Fqvw0aYI8", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
     ];
 
     // add assets

--- a/scripts/subgraph_data.js
+++ b/scripts/subgraph_data.js
@@ -21,12 +21,12 @@ async function deployContract(factory, developer, rate, uri) {
 
 async function addRawrshakAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/oYnTrb5bUIm1lgbTpBFZ9LLPVeDpDxb_vW1XBNfzlgI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
-        [1, "https://arweave.net/GFVxBPSj-bSQ_bi5ZIaxJV1fKm63pI0Dcc_qwMZIvg0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
-        [2, "https://arweave.net/y2b16LSQOqmjUeckSCltiH4_8XP3GVZVgps0N6eG6HI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
-        [3, "https://arweave.net/pIXtTejDqULTO16tOhcA5goEoeC8kMufmxZrpUkAZPA", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
-        [4, "https://arweave.net/BT067qgPxUoMQOogSvxPRIwwIwv-eKf7xb-rzeRWvSU", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
-        [5, "https://arweave.net/pOiwYzVm9_VVuVtdWqgaw57A1A9c3vdxeNG9d3cgZuM", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
+        ["https://arweave.net/oYnTrb5bUIm1lgbTpBFZ9LLPVeDpDxb_vW1XBNfzlgI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
+        ["https://arweave.net/GFVxBPSj-bSQ_bi5ZIaxJV1fKm63pI0Dcc_qwMZIvg0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
+        ["https://arweave.net/y2b16LSQOqmjUeckSCltiH4_8XP3GVZVgps0N6eG6HI", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
+        ["https://arweave.net/pIXtTejDqULTO16tOhcA5goEoeC8kMufmxZrpUkAZPA", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
+        ["https://arweave.net/BT067qgPxUoMQOogSvxPRIwwIwv-eKf7xb-rzeRWvSU", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
+        ["https://arweave.net/pOiwYzVm9_VVuVtdWqgaw57A1A9c3vdxeNG9d3cgZuM", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
     ];
 
     // add assets
@@ -39,15 +39,15 @@ async function addRawrshakAssets(content, contentManager, developer) {
 
 async function addScreamFortress2Assets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/Rg_ldKekDpRydL52p0EQeG7LnCHAzd6_ehE59omkl38", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
-        [1, "https://arweave.net/Z90dMMhDYK5d9vP0LDMdDDd4lnwEXCwJjHcbXfdIySw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
-        [2, "https://arweave.net/xSQgeZmVwzQjWfad6AfrIWXPcvivMXXFa_GaynnvliY", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
-        [3, "https://arweave.net/QOu6LWgWwoOpSfKJC21Zc8HgRKdpamMLpgRciWLzcQw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
-        [4, "https://arweave.net/uJxDoYDITlNAH14tXIOP8he_AuGHZ5ZHW_XL342Laj0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
-        [5, "https://arweave.net/TmSZJve-3-Ckpa-zlWgksIT2A-dqDxdnxdUBitxB1Lw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
-        [6, "https://arweave.net/W3h0XvASvmYZfuX6JV1s2AHEoAbTXxSpEarjFLi65Nc", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
-        [7, "https://arweave.net/OFpQMdO9D9VNh0CYg3lfJNtOT_l3XpTAFq19-saDkJU", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
-        [8, "https://arweave.net/NS-yuTTqq_wCY5wVwdSv_cipRM5GgUirL8rN4jesDfg", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
+        ["https://arweave.net/Rg_ldKekDpRydL52p0EQeG7LnCHAzd6_ehE59omkl38", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
+        ["https://arweave.net/Z90dMMhDYK5d9vP0LDMdDDd4lnwEXCwJjHcbXfdIySw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
+        ["https://arweave.net/xSQgeZmVwzQjWfad6AfrIWXPcvivMXXFa_GaynnvliY", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
+        ["https://arweave.net/QOu6LWgWwoOpSfKJC21Zc8HgRKdpamMLpgRciWLzcQw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
+        ["https://arweave.net/uJxDoYDITlNAH14tXIOP8he_AuGHZ5ZHW_XL342Laj0", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
+        ["https://arweave.net/TmSZJve-3-Ckpa-zlWgksIT2A-dqDxdnxdUBitxB1Lw", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
+        ["https://arweave.net/W3h0XvASvmYZfuX6JV1s2AHEoAbTXxSpEarjFLi65Nc", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
+        ["https://arweave.net/OFpQMdO9D9VNh0CYg3lfJNtOT_l3XpTAFq19-saDkJU", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
+        ["https://arweave.net/NS-yuTTqq_wCY5wVwdSv_cipRM5GgUirL8rN4jesDfg", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
     ];
 
     // add assets
@@ -60,10 +60,10 @@ async function addScreamFortress2Assets(content, contentManager, developer) {
 
 async function addFightBuddyAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/cg2N77GOOcKriioxIwEeeW3mU-a4XlTa6GOt1BQixIE", "", 1000, developer.address, 10000],         // Nikolai
-        [1, "https://arweave.net/ULuMJ7q_8uomd-tG2FWb-n2ZnlX_4deteFGzsv1MzkY", "", 1000, developer.address, 20000],         // Didier
-        [2, "https://arweave.net/qT_Se_bUb-HVE3JIOVzNFLgKc3m0t5hmEhml7X1WWLg", "", 500, ethers.constants.AddressZero, 0],   // Josip
-        [3, "https://arweave.net/tWfM7C5a-mC1Q6mU76Ik62iE3jYsl9QrB9mgvTAwsm8", "", 50, developer.address, 30000]            // Glenn
+        ["https://arweave.net/cg2N77GOOcKriioxIwEeeW3mU-a4XlTa6GOt1BQixIE", "", 1000, developer.address, 10000],         // Nikolai
+        ["https://arweave.net/ULuMJ7q_8uomd-tG2FWb-n2ZnlX_4deteFGzsv1MzkY", "", 1000, developer.address, 20000],         // Didier
+        ["https://arweave.net/qT_Se_bUb-HVE3JIOVzNFLgKc3m0t5hmEhml7X1WWLg", "", 500, ethers.constants.AddressZero, 0],   // Josip
+        ["https://arweave.net/tWfM7C5a-mC1Q6mU76Ik62iE3jYsl9QrB9mgvTAwsm8", "", 50, developer.address, 30000]            // Glenn
     ];
 
     // add assets
@@ -76,10 +76,10 @@ async function addFightBuddyAssets(content, contentManager, developer) {
 
 async function addSuperScaryHorrorGameAssets(content, contentManager, developer) {
     var asset = [
-        [0, "https://arweave.net/lfLN2kypyClSFDXV_UbcDAr-IkNUNTHykCVx2uZueCg", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
-        [1, "https://arweave.net/CtIZH6MptmKwZJ0h1QgRYZ3LxTmYRn52dHOkdn5OQyc", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
-        [2, "https://arweave.net/62GxTC26d3ZuD67hXHWFSCbyIfgw6bRIkavumyRGt9M", "", 50, ethers.constants.AddressZero, 0],    // Screamer
-        [3, "https://arweave.net/dCI3wOGGNXQb_WzwsNik7gzKQ5YDZFp_Q_Fqvw0aYI8", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
+        ["https://arweave.net/lfLN2kypyClSFDXV_UbcDAr-IkNUNTHykCVx2uZueCg", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
+        ["https://arweave.net/CtIZH6MptmKwZJ0h1QgRYZ3LxTmYRn52dHOkdn5OQyc", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
+        ["https://arweave.net/62GxTC26d3ZuD67hXHWFSCbyIfgw6bRIkavumyRGt9M", "", 50, ethers.constants.AddressZero, 0],    // Screamer
+        ["https://arweave.net/dCI3wOGGNXQb_WzwsNik7gzKQ5YDZFp_Q_Fqvw0aYI8", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
     ];
 
     // add assets

--- a/scripts/subgraph_ipfs_data.js
+++ b/scripts/subgraph_ipfs_data.js
@@ -21,12 +21,12 @@ async function deployContract(factory, developer, rate, uri) {
 
 async function addRawrshakAssets(content, contentManager, developer) {
     var asset = [
-        [0, "QmTgLKGxFapNAaKSoaXZkx3vq9xiarfag3cjcByUywzf7h", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
-        [1, "QmX1Epc144wovBa3i8LVy6JoVxUpVjuA7nQvDmigo8NAx7", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
-        [2, "QmaCGZKewUkJCw7nHtvMCTxxeeg1fNhF1BGKVowAAh5dJn", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
-        [3, "QmeZ9t91M5AizHBwPHt7ZYEzvhS9ic98eQ8BUQ7bZrERBT", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
-        [4, "QmUcUdn8Gf9hiwqvmN9SzP4JZsrC72CpPLptXwjyW8Nuv3", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
-        [5, "QmWGDc6HM4oXXmhkDYKLcL95anW5Wsxmw6daUrc2KL82fa", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
+        ["QmTgLKGxFapNAaKSoaXZkx3vq9xiarfag3cjcByUywzf7h", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Apprentice Title
+        ["QmX1Epc144wovBa3i8LVy6JoVxUpVjuA7nQvDmigo8NAx7", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Creator Title
+        ["QmaCGZKewUkJCw7nHtvMCTxxeeg1fNhF1BGKVowAAh5dJn", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Gamer Pesant Title
+        ["QmeZ9t91M5AizHBwPHt7ZYEzvhS9ic98eQ8BUQ7bZrERBT", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Disciple Title
+        ["QmUcUdn8Gf9hiwqvmN9SzP4JZsrC72CpPLptXwjyW8Nuv3", "", ethers.constants.MaxUint256, developer.address, 20000],          // Lord Title
+        ["QmWGDc6HM4oXXmhkDYKLcL95anW5Wsxmw6daUrc2KL82fa", "", ethers.constants.MaxUint256, developer.address, 20000]           // Original Sinner Title
     ];
 
     // add assets
@@ -39,15 +39,15 @@ async function addRawrshakAssets(content, contentManager, developer) {
 
 async function addScreamFortress2Assets(content, contentManager, developer) {
     var asset = [
-        [0, "QmPdzEWnW1PAxm4LFe5pRw3g5kNee8oKKtbs92sVekMce4", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
-        [1, "QmPC6iFFc1ewqVCcfPyyG4YssL6zwX9DW2VQDD5K6P3PLD", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
-        [2, "QmXVeyvvDhknXuH2CevPUGxjDFXDPRTxS7k6Ehm7jRVSHH", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
-        [3, "QmVqWJPhcchCSp22FQSxxzRZMFVpae2fMSa3sPbmHywXCC", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
-        [4, "QmbTvdvL2CUPpBVf7LvFb25t2JdqqGjumed5bVaSpyCZYx", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
-        [5, "QmWroKamTeD2hr66ERDGXG7axLzagK2p48BBuBwjN7TFrF", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
-        [6, "QmaUz6wBvxTFJBdcJRy59nMPNm78CKMjwuqYgfvGBUwZ52", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
-        [7, "QmNbQxN82JweyESPP9tCVMroVA1itf974pLknMjkt3Eo2k", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
-        [8, "QmSPTeM11qMLKWMtqrvPDV1FxEDEkjQ5HZjJmQfkGq4DZt", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
+        ["QmPdzEWnW1PAxm4LFe5pRw3g5kNee8oKKtbs92sVekMce4", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Demoman
+        ["QmPC6iFFc1ewqVCcfPyyG4YssL6zwX9DW2VQDD5K6P3PLD", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Engineer
+        ["QmXVeyvvDhknXuH2CevPUGxjDFXDPRTxS7k6Ehm7jRVSHH", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Heavy
+        ["QmVqWJPhcchCSp22FQSxxzRZMFVpae2fMSa3sPbmHywXCC", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Medic
+        ["QmbTvdvL2CUPpBVf7LvFb25t2JdqqGjumed5bVaSpyCZYx", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Pyro
+        ["QmWroKamTeD2hr66ERDGXG7axLzagK2p48BBuBwjN7TFrF", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Scout
+        ["QmaUz6wBvxTFJBdcJRy59nMPNm78CKMjwuqYgfvGBUwZ52", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Sniper
+        ["QmNbQxN82JweyESPP9tCVMroVA1itf974pLknMjkt3Eo2k", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0],   // Soldier
+        ["QmSPTeM11qMLKWMtqrvPDV1FxEDEkjQ5HZjJmQfkGq4DZt", "", ethers.constants.MaxUint256, ethers.constants.AddressZero, 0]    // Spy
     ];
 
     // add assets
@@ -60,10 +60,10 @@ async function addScreamFortress2Assets(content, contentManager, developer) {
 
 async function addFightBuddyAssets(content, contentManager, developer) {
     var asset = [
-        [0, "QmPFJoS7UKXmmXeA4HMes1K5GRNM2QQ94hf6dSUqH3i2wF", "", 1000, developer.address, 10000],         // Nikolai
-        [1, "Qma3cwsq1kqcAP6zudnr1WyWWkXhVnYa1wgRAun8op9nGa", "", 1000, developer.address, 20000],         // Didier
-        [2, "Qma7QXrm9wUFmdxBWT32fWccfQ6kvNeZS598eMdVuBvthU", "", 500, ethers.constants.AddressZero, 0],   // Josip
-        [3, "QmRde9qaDmyDrxEpHPC5ycnt36S375WUaBpSrDuemE68Vn", "", 50, developer.address, 30000]            // Glenn
+        ["QmPFJoS7UKXmmXeA4HMes1K5GRNM2QQ94hf6dSUqH3i2wF", "", 1000, developer.address, 10000],         // Nikolai
+        ["Qma3cwsq1kqcAP6zudnr1WyWWkXhVnYa1wgRAun8op9nGa", "", 1000, developer.address, 20000],         // Didier
+        ["Qma7QXrm9wUFmdxBWT32fWccfQ6kvNeZS598eMdVuBvthU", "", 500, ethers.constants.AddressZero, 0],   // Josip
+        ["QmRde9qaDmyDrxEpHPC5ycnt36S375WUaBpSrDuemE68Vn", "", 50, developer.address, 30000]            // Glenn
     ];
 
     // add assets
@@ -76,10 +76,10 @@ async function addFightBuddyAssets(content, contentManager, developer) {
 
 async function addSuperScaryHorrorGameAssets(content, contentManager, developer) {
     var asset = [
-        [0, "QmXnMAmDwKuMsmWLc6dnccwaGqLMXyGHBjEvC9oHePNvFX", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
-        [1, "QmfMoQt1LGs7PN5UYP2kikkuYpHJiFHGx2EHCPaEuLZ7Kt", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
-        [2, "QmRpA8dRsLhzwGifk2yV4fcTJpAP89s3Mmm5X1qqH5Xwza", "", 50, ethers.constants.AddressZero, 0],    // Screamer
-        [3, "QmZMpYizqKeSVFtQrWWYSmPK93yWHJgFsvFYZuKaQz8QXn", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
+        ["QmXnMAmDwKuMsmWLc6dnccwaGqLMXyGHBjEvC9oHePNvFX", "", 10000, ethers.constants.AddressZero, 0], // Scary Terry
+        ["QmfMoQt1LGs7PN5UYP2kikkuYpHJiFHGx2EHCPaEuLZ7Kt", "", 50, ethers.constants.AddressZero, 0],    // Casper the Ghost
+        ["QmRpA8dRsLhzwGifk2yV4fcTJpAP89s3Mmm5X1qqH5Xwza", "", 50, ethers.constants.AddressZero, 0],    // Screamer
+        ["QmZMpYizqKeSVFtQrWWYSmPK93yWHJgFsvFYZuKaQz8QXn", "", 25, ethers.constants.AddressZero, 0]     // Headless Canadian
     ];
 
     // add assets

--- a/test/content/ContentManagerTests.js
+++ b/test/content/ContentManagerTests.js
@@ -16,8 +16,8 @@ describe('Content Manager Contract Tests', () => {
         ContentManager = await ethers.getContractFactory("ContentManager");
         ContentFactory = await ethers.getContractFactory("ContentFactory");
         asset = [
-            [1, "arweave.net/tx/public-uri-1", "", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-            [2, "arweave.net/tx/public-uri-2", "", 100, ethers.constants.AddressZero, 0],
+            ["arweave.net/tx/public-uri-0", "", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-1", "", 100, ethers.constants.AddressZero, 0],
         ];
     });
 
@@ -43,7 +43,7 @@ describe('Content Manager Contract Tests', () => {
         var approvalPair = [[craftingSystemAddress.address, true]];
         await contentManager.registerOperators(approvalPair);
 
-        // // Add 1 asset
+        // Add 2 assets
         await contentManager.addAssetBatch(asset);
     });
 
@@ -54,7 +54,7 @@ describe('Content Manager Contract Tests', () => {
 
         it('Check Supported interfaces', async () => {
             // Content Manager interface
-            expect(await contentManager.supportsInterface("0xa15f6002")).to.equal(true);
+            expect(await contentManager.supportsInterface("0x007a1753")).to.equal(true);
         });
     });
 
@@ -62,64 +62,64 @@ describe('Content Manager Contract Tests', () => {
         it('Add Single Asset', async () => {
             // Add 1 asset
             var newAssets = [
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 1000, ethers.constants.AddressZero, 0]
+                ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 1000, ethers.constants.AddressZero, 0]
             ];
             
             await contentManager.addAssetBatch(newAssets);
 
             // const signature = await sign(playerAddress, [1], [1], 1, null, content.address);
-            var mintData = [playerAddress.address, [3], [10], 1, ethers.constants.AddressZero, []];
+            var mintData = [playerAddress.address, [2], [10], 1, ethers.constants.AddressZero, []];
             await content.connect(craftingSystemAddress).mintBatch(mintData);
 
-            expect(await content['uri(uint256)'](3)).to.equal("arweave.net/tx/public-uri-3");
+            expect(await content['uri(uint256)'](2)).to.equal("arweave.net/tx/public-uri-2");
         });
 
         it('Add Mulitple Assets', async () => {
             // Add 3 assets
             var newAssets = [
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 1000, deployerAddress.address, 10000],
-                [4, "arweave.net/tx/public-uri-4", "arweave.net/tx/private-uri-4", 20, ethers.constants.AddressZero, 0],
-                [5, "arweave.net/tx/public-uri-5", "arweave.net/tx/private-uri-5", 1, deployerAddress.address, 50000]
+                ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 1000, deployerAddress.address, 10000],
+                ["arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 20, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-4", "arweave.net/tx/private-uri-4", 1, deployerAddress.address, 50000]
             ];
             
             await contentManager.addAssetBatch(newAssets);
 
             // const signature = await sign(playerAddress, [1], [1], 1, null, content.address);
-            var mintData = [playerAddress.address, [3, 4, 5], [10, 2, 1], 1, ethers.constants.AddressZero, []];
+            var mintData = [playerAddress.address, [2, 3, 4], [10, 2, 1], 1, ethers.constants.AddressZero, []];
             await content.connect(craftingSystemAddress).mintBatch(mintData);
 
-            expect(await content['uri(uint256)'](3)).to.equal("arweave.net/tx/public-uri-3");
-            expect(await content.totalSupply(4)).to.equal(2);
-            expect(await content.maxSupply(5)).to.equal(1);
+            expect(await content['uri(uint256)'](2)).to.equal("arweave.net/tx/public-uri-2");
+            expect(await content.totalSupply(3)).to.equal(2);
+            expect(await content.maxSupply(4)).to.equal(1);
         });
 
         it('Set Token URI', async () => {
             var assetUri = [
-                [2, "arweave.net/tx/public-uri-2-v1"]
+                [1, "arweave.net/tx/public-uri-1-v1"]
             ];
             await contentManager.setPublicUriBatch(assetUri);
 
-            var mintData = [playerAddress.address, [2], [1], 1, ethers.constants.AddressZero, []];
+            var mintData = [playerAddress.address, [1], [1], 1, ethers.constants.AddressZero, []];
             await content.connect(craftingSystemAddress).mintBatch(mintData);
 
-            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](2, 0)).to.equal("arweave.net/tx/public-uri-2");
-            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](2, 1)).to.equal("arweave.net/tx/public-uri-2-v1");
-            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](2, 2)).to.equal("arweave.net/tx/public-uri-2-v1");
+            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](1, 0)).to.equal("arweave.net/tx/public-uri-1");
+            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](1, 1)).to.equal("arweave.net/tx/public-uri-1-v1");
+            expect(await content.connect(playerAddress)['uri(uint256,uint256)'](1, 2)).to.equal("arweave.net/tx/public-uri-1-v1");
         });
 
         it('Set Token Contract Royalties', async () => {
             await contentManager.setContractRoyalty(deployerAddress.address, 20000);
 
-            var fees = await content.royaltyInfo(2, 1000);
+            var fees = await content.royaltyInfo(1, 1000);
             expect(fees.receiver).to.equal(deployerAddress.address);
             expect(fees.royaltyAmount).to.equal(20);
         });
 
         it('Set Token Royalties', async () => {
-            var assetRoyalty = [[1, deployerAddress.address, 10000]];
+            var assetRoyalty = [[0, deployerAddress.address, 10000]];
             await contentManager.setTokenRoyaltiesBatch(assetRoyalty);
 
-            var fees = await content.royaltyInfo(2, 1000);
+            var fees = await content.royaltyInfo(1, 1000);
             expect(fees.receiver).to.equal(deployerAddress.address);
             expect(fees.royaltyAmount).to.equal(10);
         });
@@ -127,7 +127,7 @@ describe('Content Manager Contract Tests', () => {
 
     describe("Register Operator Tests", () => {
         it('Same operator address', async () => {
-            var mintData = [playerAddress.address, [2], [5], 1, ethers.constants.AddressZero, []];
+            var mintData = [playerAddress.address, [1], [5], 1, ethers.constants.AddressZero, []];
 
             // craftingSystemAddress should have minter role revoked
             var approvalPairs1 = [
@@ -139,7 +139,7 @@ describe('Content Manager Contract Tests', () => {
             await contentManager.registerOperators(approvalPairs1);
             await expect(content.connect(craftingSystemAddress).mintBatch(mintData)).to.be.reverted;
 
-            expect(await content.totalSupply(2)).to.equal(0);
+            expect(await content.totalSupply(1)).to.equal(0);
 
             // craftingSystemAddress should have minter role granted
             var approvalPairs2 = [
@@ -150,11 +150,11 @@ describe('Content Manager Contract Tests', () => {
 
             await contentManager.registerOperators(approvalPairs2);
             await content.connect(craftingSystemAddress).mintBatch(mintData);
-            expect(await content.totalSupply(2)).to.equal(5);
+            expect(await content.totalSupply(1)).to.equal(5);
         });
 
         it('Edge case parameters', async () => {
-            var mintData = [playerAddress.address, [1], [100], 1, ethers.constants.AddressZero, []];
+            var mintData = [playerAddress.address, [0], [100], 1, ethers.constants.AddressZero, []];
 
             var approvalPairs1 = [[null, true]];
             var approvalPairs2 = [["", false]];
@@ -166,7 +166,7 @@ describe('Content Manager Contract Tests', () => {
             await contentManager.registerOperators(approvalPairs3);
             
             await content.connect(craftingSystemAddress).mintBatch(mintData);
-            expect(await content.totalSupply(1)).to.equal(100);
+            expect(await content.totalSupply(0)).to.equal(100);
         });
     });
 });

--- a/test/content/ContentStorageTests.js
+++ b/test/content/ContentStorageTests.js
@@ -25,7 +25,7 @@ describe('ContentStorage Contract Tests', () => {
         
         it('Check ContentStorage Contract Interfaces', async () => {
             // IContentStorage Interface
-            expect(await contentStorage.supportsInterface("0xac73f1f1")).to.equal(true);
+            expect(await contentStorage.supportsInterface("0xbc04328a")).to.equal(true);
 
             // IContentSubsystemBase Interface
             expect(await contentStorage.supportsInterface("0x7460af1d")).to.equal(true);
@@ -45,125 +45,105 @@ describe('ContentStorage Contract Tests', () => {
         });
 
         it('Unauthorized caller', async () => {
-            var asset = [[1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1",  100, deployerAddress.address, 20000]];
+            var asset = [["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0",  100, deployerAddress.address, 20000]];
             await contentStorage.addAssetBatch(asset);
 
-            await expect(contentStorage.connect(playerAddress).updateSupply(1, 50)).to.be.reverted;
-            await expect(contentStorage.connect(playerAddress).setPublicUriBatch([[1, ""]])).to.be.reverted;
-            await expect(contentStorage.connect(playerAddress).setHiddenUriBatch([[1, ""]])).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).updateSupply(0, 50)).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).setPublicUriBatch([[0, ""]])).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).setHiddenUriBatch([[0, ""]])).to.be.reverted;
             await expect(contentStorage.connect(playerAddress).setContractRoyalty(playerAddress.address, 1000000)).to.be.reverted;
-            await expect(contentStorage.connect(playerAddress).setTokenRoyaltiesBatch([[1, playerAddress.address, 500000]])).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).setTokenRoyaltiesBatch([[0, playerAddress.address, 500000]])).to.be.reverted;
         });
     });
     
     describe("Assets Info", () => {
         // CreateData
         // {
-        //     tokenId,
-        //     dataUri,
-        //     maxSupply,
-        //     [
-        //         {
-        //             account,
-        //             rate
-        //         }
-        //     ]
+        //     publicDataUri,
+        //     hiddenDataUri,
+        //     maxSupply
+        //     royaltyReceiver,
+        //     royaltyRate
         // }
     
         it('Add single asset', async () => {
-            var asset = [[1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1",  100, deployerAddress.address, 20000]];
+            var asset = [["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0",  100, deployerAddress.address, 20000]];
             var results = await contentStorage.addAssetBatch(asset);
     
             await expect(results)
                 .to.emit(contentStorage, 'TokenRoyaltyUpdated')
-                .withArgs(ethers.constants.AddressZero, 1, deployerAddress.address, 20000);
+                .withArgs(ethers.constants.AddressZero, 0, deployerAddress.address, 20000);
 
             await expect(results)
                 .to.emit(contentStorage, 'PublicUriUpdated')
-                .withArgs(ethers.constants.AddressZero, 1, 0);
+                .withArgs(ethers.constants.AddressZero, 0, 0);
                 
             await expect(results)
                 .to.emit(contentStorage, 'HiddenUriUpdated')
-                .withArgs(ethers.constants.AddressZero, 1, 0);
+                .withArgs(ethers.constants.AddressZero, 0, 0);
             
             await expect(results)
                 .to.emit(contentStorage, 'AssetsAdded');
             
-            expect(await contentStorage.ids(1))
-                .to.equal(true);
-            expect(await contentStorage.supply(1))
+            expect(await contentStorage.assetCounter())
+                .to.equal(1);
+            expect(await contentStorage.supply(0))
                 .to.equal(0);
-            expect(await contentStorage.maxSupply(1))
+            expect(await contentStorage.maxSupply(0))
                 .to.equal(100);
             
-            tokenFees = await contentStorage.getRoyalty(1);
+            tokenFees = await contentStorage.getRoyalty(0);
             expect(tokenFees.receiver).to.equal(deployerAddress.address);
             expect(tokenFees.rate).to.equal(20000);
             
-            expect(await contentStorage.uri(1, 0)).to.equal("arweave.net/tx/public-uri-1");
-            expect(await contentStorage.hiddenUri(1, 0)).to.equal("arweave.net/tx/private-uri-1");
+            expect(await contentStorage.uri(0, 0)).to.equal("arweave.net/tx/public-uri-0");
+            expect(await contentStorage.hiddenUri(0, 0)).to.equal("arweave.net/tx/private-uri-0");
         });
 
         it('Add multiple assets', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0]
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0]
             ];
             var results = await contentStorage.addAssetBatch(asset);
             
             // Check the token URIs
             await expect(results)
                 .to.emit(contentStorage, 'HiddenUriUpdated')
-                .withArgs(ethers.constants.AddressZero, 1, 0);
+                .withArgs(ethers.constants.AddressZero, 0, 0);
             
             await expect(results)
                 .to.emit(contentStorage, 'PublicUriUpdated')
-                .withArgs(ethers.constants.AddressZero, 2, 0);
+                .withArgs(ethers.constants.AddressZero, 1, 0);
 
             await expect(results)
                 .to.emit(contentStorage, 'TokenRoyaltyUpdated')
-                .withArgs(ethers.constants.AddressZero, 1, deployerAddress.address, 20000);
+                .withArgs(ethers.constants.AddressZero, 0, deployerAddress.address, 20000);
             
             await expect(results)
                 .to.emit(contentStorage, 'AssetsAdded');
             
-            expect(await contentStorage.ids(2))
-                .to.equal(true);
-            expect(await contentStorage.supply(1))
+            expect(await contentStorage.assetCounter())
+                .to.equal(2);
+            expect(await contentStorage.supply(0))
                 .to.equal(0);
-            expect(await contentStorage.maxSupply(2))
+            expect(await contentStorage.maxSupply(1))
                 .to.equal(10);
         });
 
         it('Add mutliple assets, one with invalid fee', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 1000, deployerAddress.address, 2000000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, deployerAddress.address, 0]
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", 1000, deployerAddress.address, 2000000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, deployerAddress.address, 0]
             ];
             await expect(contentStorage.addAssetBatch(asset)).to.be.reverted;
         });
 
-        it('Add an already existing token', async () => {
-            var asset1 = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000]];
-            await contentStorage.addAssetBatch(asset1);
-
-            var asset2 = [
-                [1, "arweave.net/tx/public-uri-1v2", "arweave.net/tx/private-uri-1v2", 1, deployerAddress.address, 30000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 0, deployerAddress.address, 1000000]
-            ];
-            await expect(contentStorage.addAssetBatch(asset2)).to.be.reverted;
-            
-            expect(await contentStorage.ids(2)).to.equal(false);
-            expect(await contentStorage.ids(3)).to.equal(false);
-        });
-
         it('Set max supply to zero', async () => {
-            var asset = [[1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1",  0, deployerAddress.address, 30000]];
+            var asset = [["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0",  0, deployerAddress.address, 30000]];
             var results = await contentStorage.addAssetBatch(asset);
     
-            expect(await contentStorage.maxSupply(1))
+            expect(await contentStorage.maxSupply(0))
                 .to.equal(ethers.constants.MaxUint256);
         });
     });
@@ -171,134 +151,134 @@ describe('ContentStorage Contract Tests', () => {
     describe("Contract Interactions", () => {
         
         it('Update the current asset supply', async () => {
-            var asset = [[1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 100, deployerAddress.address, 20000]];
+            var asset = [["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", 100, deployerAddress.address, 20000]];
             await contentStorage.addAssetBatch(asset);
 
-            expect(await contentStorage.supply(1)).to.equal(0);
+            expect(await contentStorage.supply(0)).to.equal(0);
 
-            await contentStorage.updateSupply(1, 5); 
+            await contentStorage.updateSupply(0, 5); 
 
-            expect(await contentStorage.supply(1)).to.equal(5);
+            expect(await contentStorage.supply(0)).to.equal(5);
         });
         
         it('Basic Royalties tests', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0],
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 10, deployerAddress.address, 30000]
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, deployerAddress.address, 30000]
             ];
             await contentStorage.addAssetBatch(asset);
 
-            tokenFees = await contentStorage.getRoyalty(1);
+            tokenFees = await contentStorage.getRoyalty(0);
             expect(tokenFees.receiver).to.equal(deployerAddress.address);
             expect(tokenFees.rate).to.equal(20000);
                 
-            tokenFees = await contentStorage.getRoyalty(2);
+            tokenFees = await contentStorage.getRoyalty(1);
             expect(tokenFees.receiver).to.equal(deployerAddress.address);
             expect(tokenFees.rate).to.equal(10000);
                 
-            tokenFees = await contentStorage.getRoyalty(3);
+            tokenFees = await contentStorage.getRoyalty(2);
             expect(tokenFees.receiver).to.equal(deployerAddress.address);
             expect(tokenFees.rate).to.equal(30000);
         });
 
         it('Basic Uri tests', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0],
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 10, ethers.constants.AddressZero, 0]
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, deployerAddress.address, 0]
             ];
             await contentStorage.addAssetBatch(asset);
 
             // Test Public Uri
+            expect(await contentStorage.uri(0, 0)).to.equal("arweave.net/tx/public-uri-0");
             expect(await contentStorage.uri(1, 0)).to.equal("arweave.net/tx/public-uri-1");
             expect(await contentStorage.uri(2, 0)).to.equal("arweave.net/tx/public-uri-2");
-            expect(await contentStorage.uri(3, 0)).to.equal("arweave.net/tx/public-uri-3");
                 
             // Test Hidden Uri
+            expect(await contentStorage.hiddenUri(0, 0)).to.equal("arweave.net/tx/private-uri-0");
             expect(await contentStorage.hiddenUri(1, 0)).to.equal("arweave.net/tx/private-uri-1");
             expect(await contentStorage.hiddenUri(2, 0)).to.equal("arweave.net/tx/private-uri-2");
-            expect(await contentStorage.hiddenUri(3, 0)).to.equal("arweave.net/tx/private-uri-3");
                 
             // Update Asset 2
             var assetUri = [
-                [2, "arweave.net/tx/private-uri-2v1"]
+                [1, "arweave.net/tx/private-uri-1v1"]
             ];
             
             await expect(contentStorage.setHiddenUriBatch(assetUri))
                 .to.emit(contentStorage, 'HiddenUriUpdated');
             
-            expect(await contentStorage.hiddenUri(2, 1)).to.equal("arweave.net/tx/private-uri-2v1");
+            expect(await contentStorage.hiddenUri(1, 1)).to.equal("arweave.net/tx/private-uri-1v1");
                 
             // Update Asset 3
             var assetUri = [
-                [3, "arweave.net/tx/public-uri-3v1"]
+                [2, "arweave.net/tx/public-uri-2v1"]
             ];
             
             await expect(contentStorage.setPublicUriBatch(assetUri))
                 .to.emit(contentStorage, 'PublicUriUpdated');
                 
-            expect(await contentStorage.uri(3, 1)).to.equal("arweave.net/tx/public-uri-3v1");
+            expect(await contentStorage.uri(2, 1)).to.equal("arweave.net/tx/public-uri-2v1");
         });
 
         it('Set multiple public uri', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0],
             ];
             await contentStorage.addAssetBatch(asset);
 
+            expect(await contentStorage.uri(0, 0)).to.equal("arweave.net/tx/public-uri-0");
             expect(await contentStorage.uri(1, 0)).to.equal("arweave.net/tx/public-uri-1");
-            expect(await contentStorage.uri(2, 0)).to.equal("arweave.net/tx/public-uri-2");
 
-            var assetUri = [[1, "arweave.net/tx/public-uri-1v2"],[2, "arweave.net/tx/public-uri-2v2"]];
+            var assetUri = [[0, "arweave.net/tx/public-uri-0v2"],[1, "arweave.net/tx/public-uri-1v2"]];
             await expect(contentStorage.setPublicUriBatch(assetUri))
                 .to.emit(contentStorage, 'PublicUriUpdated');
 
-            expect(await contentStorage.uri(1, 1)).to.equal("arweave.net/tx/public-uri-1v2");
-            expect(await contentStorage.uri(2, 1)).to.equal("arweave.net/tx/public-uri-2v2"); 
+            expect(await contentStorage.uri(0, 1)).to.equal("arweave.net/tx/public-uri-0v2");
+            expect(await contentStorage.uri(1, 1)).to.equal("arweave.net/tx/public-uri-1v2"); 
         });
 
         it('Set multiple hidden uri', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0],
             ];
             await contentStorage.addAssetBatch(asset);
 
+            expect(await contentStorage.hiddenUri(0, 0)).to.equal("arweave.net/tx/private-uri-0");
             expect(await contentStorage.hiddenUri(1, 0)).to.equal("arweave.net/tx/private-uri-1");
-            expect(await contentStorage.hiddenUri(2, 0)).to.equal("arweave.net/tx/private-uri-2");
 
-            var assetUri = [[1, "arweave.net/tx/private-uri-1v2"],[2, "arweave.net/tx/private-uri-2v2"]];
+            var assetUri = [[0, "arweave.net/tx/private-uri-0v2"],[1, "arweave.net/tx/private-uri-1v2"]];
             await expect(contentStorage.setHiddenUriBatch(assetUri))
                 .to.emit(contentStorage, 'HiddenUriUpdated');
 
+            expect(await contentStorage.hiddenUri(0, 1)).to.equal("arweave.net/tx/private-uri-0v2");
             expect(await contentStorage.hiddenUri(1, 1)).to.equal("arweave.net/tx/private-uri-1v2");
-            expect(await contentStorage.hiddenUri(2, 1)).to.equal("arweave.net/tx/private-uri-2v2");
         });
 
         it('Set multiple token royalties', async () => {
             var asset = [
-                [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-                [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 10, ethers.constants.AddressZero, 0],
-                [3, "arweave.net/tx/public-uri-3", "arweave.net/tx/private-uri-3", 1000, deployerAddress.address, 15000],
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+                ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, ethers.constants.AddressZero, 0],
+                ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 1000, deployerAddress.address, 15000],
             ];
             await contentStorage.addAssetBatch(asset);
 
-            expect((await contentStorage.getRoyalty(1)).rate).to.equal(20000);
-            expect((await contentStorage.getRoyalty(2)).rate).to.equal(10000);
-            expect((await contentStorage.getRoyalty(3)).rate).to.equal(15000);
+            expect((await contentStorage.getRoyalty(0)).rate).to.equal(20000);
+            expect((await contentStorage.getRoyalty(1)).rate).to.equal(10000);
+            expect((await contentStorage.getRoyalty(2)).rate).to.equal(15000);
 
             var tokenRoyalty = [
-                [1, deployerAddress.address, 0], [2, deployerAddress.address, 30000], 
-                [3, ethers.constants.AddressZero, 5]
+                [0, deployerAddress.address, 0], [1, deployerAddress.address, 30000], 
+                [2, ethers.constants.AddressZero, 5]
             ];
             await expect(contentStorage.setTokenRoyaltiesBatch(tokenRoyalty))
                 .to.emit(contentStorage, 'TokenRoyaltyUpdated');
 
-            expect((await contentStorage.getRoyalty(1)).rate).to.equal(0);
-            expect((await contentStorage.getRoyalty(2)).rate).to.equal(30000);
-            expect((await contentStorage.getRoyalty(3)).rate).to.equal(10000);
+            expect((await contentStorage.getRoyalty(0)).rate).to.equal(0);
+            expect((await contentStorage.getRoyalty(1)).rate).to.equal(30000);
+            expect((await contentStorage.getRoyalty(2)).rate).to.equal(10000);
         });
     });
 

--- a/test/content/ContentTests.js
+++ b/test/content/ContentTests.js
@@ -16,8 +16,8 @@ describe('Content Contract Tests', () => {
         ContentStorage = await ethers.getContractFactory("ContentStorage");
         Content = await ethers.getContractFactory("Content");
         asset = [
-            [1, "arweave.net/tx/public-uri-1", "", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-            [2, "arweave.net/tx/public-uri-2", "", 100, ethers.constants.AddressZero, 0],
+            ["arweave.net/tx/public-uri-0", "", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-1", "", 100, ethers.constants.AddressZero, 0],
         ];
     });
 
@@ -36,7 +36,7 @@ describe('Content Contract Tests', () => {
         // Set the content contract as the new parent
         await accessControlManager.setParent(content.address);
 
-        // Add 1 asset
+        // Add 2 assets
         await contentStorage.addAssetBatch(asset);
     });
 
@@ -61,18 +61,17 @@ describe('Content Contract Tests', () => {
         });
     
         it('Check Supply', async () => {
-            expect(await content.totalSupply(1)).to.equal(0);
-            expect(await content.maxSupply(1)).to.equal(ethers.constants.MaxUint256);
+            expect(await content.totalSupply(0)).to.equal(0);
+            expect(await content.maxSupply(0)).to.equal(ethers.constants.MaxUint256);
             
-            expect(await content.totalSupply(2)).to.equal(0);
-            expect(await content.maxSupply(2)).to.equal(100);
+            expect(await content.totalSupply(1)).to.equal(0);
+            expect(await content.maxSupply(1)).to.equal(100);
         });
     });
 
     describe("Storage", () => {
         // CreateData
         // {
-        //     tokenId,
         //     publicDataUri,
         //     hiddenDataUri,
         //     maxSupply
@@ -85,21 +84,21 @@ describe('Content Contract Tests', () => {
             // Note: we use content.methods['function()']() below because it hiddenUri() is an
             //       overloaded function
             
-            const signature = await sign(playerAddress.address, [1], [1], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1], [1], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0], [1], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0], [1], 1, craftingSystemAddress.address, signature];
             await content.connect(playerAddress).mintBatch(mintData);
     
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(1);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(1);
         });
 
         it("Uri", async () => {
-            expect(await content['uri(uint256,uint256)'](1, 0))
-                .to.equal("arweave.net/tx/public-uri-1");
+            expect(await content['uri(uint256,uint256)'](0, 0))
+                .to.equal("arweave.net/tx/public-uri-0");
         });
     
         it('Royalty', async () => {
             // test royalties (ERC2981)
-            var fees = await content.royaltyInfo(1, 1000);
+            var fees = await content.royaltyInfo(0, 1000);
             expect(fees.receiver).to.equal(deployerAddress.address);
             expect(fees.royaltyAmount).to.equal(20);
         });
@@ -107,14 +106,14 @@ describe('Content Contract Tests', () => {
         it('Add Assets', async () => {
             // invalid add because asset already exists
             var newAssets = [
-                [3, "arweave.net/tx/public-uri-3", "", 1000, ethers.constants.AddressZero, 0]
+                ["arweave.net/tx/public-uri-2", "", 1000, ethers.constants.AddressZero, 0]
             ];
             
             await expect(contentStorage.addAssetBatch(newAssets))
                 .to.emit(contentStorage, 'AssetsAdded');
             
-            expect(await content.totalSupply(3)).to.equal(0);
-            expect(await content.maxSupply(3)).to.equal(1000);
+            expect(await content.totalSupply(2)).to.equal(0);
+            expect(await content.maxSupply(2)).to.equal(1000);
         });
     });
 
@@ -133,20 +132,20 @@ describe('Content Contract Tests', () => {
         // }
 
         it('Mint Assets', async () => {
-            const signature = await sign(playerAddress.address, [1, 2], [10, 1], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1, 2], [10, 1], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0, 1], [10, 1], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0, 1], [10, 1], 1, craftingSystemAddress.address, signature];
             expect (await content.connect(playerAddress).mintBatch(mintData))
                 .to.emit(content, "Mint");
             
-            expect(await content.totalSupply(1)).to.equal(10);
-            expect(await content.totalSupply(2)).to.equal(1);
+            expect(await content.totalSupply(0)).to.equal(10);
+            expect(await content.totalSupply(1)).to.equal(1);
 
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(10);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(10);
         });
 
         it('Mint data length input mismatch', async () => {
-            const signature = await sign(playerAddress.address, [1, 2], [10], 1, craftingSystemAddress.address, content.address);
-            var invalidLengthData = [playerAddress.address, [1, 2], [10], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0, 1], [10], 1, craftingSystemAddress.address, content.address);
+            var invalidLengthData = [playerAddress.address, [0, 1], [10], 1, craftingSystemAddress.address, signature];
 
             await expect(content.connect(playerAddress).mintBatch(invalidLengthData)).to.be.reverted;
         });
@@ -159,89 +158,89 @@ describe('Content Contract Tests', () => {
         });
 
         it('Mint invalid supply', async () => {
-            const signature = await sign(playerAddress.address, [2], [300], 1, craftingSystemAddress.address, content.address);
-            var invalidSupplyData = [playerAddress.address, [2], [300], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [1], [300], 1, craftingSystemAddress.address, content.address);
+            var invalidSupplyData = [playerAddress.address, [1], [300], 1, craftingSystemAddress.address, signature];
             
             await expect(content.connect(playerAddress).mintBatch(invalidSupplyData)).to.be.reverted;
         });
 
         it('Mint invalid supply 2', async () => {
-            const signature = await sign(playerAddress.address, [2], [30], 1, craftingSystemAddress.address, content.address);
-            var validSupplyData = [playerAddress.address, [2], [30], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [1], [30], 1, craftingSystemAddress.address, content.address);
+            var validSupplyData = [playerAddress.address, [1], [30], 1, craftingSystemAddress.address, signature];
             
             await content.connect(playerAddress).mintBatch(validSupplyData);
 
-            expect(await content.totalSupply(2)).to.equal(30);
-            expect(await content.balanceOf(playerAddress.address, 2)).to.equal(30);
+            expect(await content.totalSupply(1)).to.equal(30);
+            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(30);
 
-            const signature2 = await sign(playerAddress.address, [2], [90], 2, craftingSystemAddress.address, content.address);
-            var invalidSupplyData = [playerAddress.address, [2], [90], 2, craftingSystemAddress.address, signature2];
+            const signature2 = await sign(playerAddress.address, [21], [90], 2, craftingSystemAddress.address, content.address);
+            var invalidSupplyData = [playerAddress.address, [1], [90], 2, craftingSystemAddress.address, signature2];
             
             await expect(content.connect(playerAddress).mintBatch(invalidSupplyData)).to.be.reverted;
-            expect(await content.totalSupply(2)).to.equal(30);
-            expect(await content.balanceOf(playerAddress.address, 2)).to.equal(30);
+            expect(await content.totalSupply(1)).to.equal(30);
+            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(30);
         });
     });
 
     describe("Burn", () => {
         it('Burn Assets', async () => {
-            const signature = await sign(playerAddress.address, [1, 2], [10, 75], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1, 2], [10, 75], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0, 1], [10, 75], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0, 1], [10, 75], 1, craftingSystemAddress.address, signature];
             await content.connect(playerAddress).mintBatch(mintData);
     
-            var burnData = [playerAddress.address, [1, 2], [5, 25]];
+            var burnData = [playerAddress.address, [0, 1], [5, 25]];
             expect (await content.connect(playerAddress).burnBatch(burnData))
                 .to.emit(content, "Burn");
 
-            expect(await content.connect(playerAddress).totalSupply(1)).to.equal(5);
-            expect(await content.connect(playerAddress).totalSupply(2)).to.equal(50);
+            expect(await content.connect(playerAddress).totalSupply(0)).to.equal(5);
+            expect(await content.connect(playerAddress).totalSupply(1)).to.equal(50);
     
             await content.connect(playerAddress).setApprovalForAll(craftingSystemAddress.address, true);
             await content.connect(craftingSystemAddress).burnBatch(burnData);
-            expect(await content.connect(playerAddress).totalSupply(1)).to.equal(0);
-            expect(await content.connect(playerAddress).totalSupply(2)).to.equal(25);
+            expect(await content.connect(playerAddress).totalSupply(0)).to.equal(0);
+            expect(await content.connect(playerAddress).totalSupply(1)).to.equal(25);
             
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(0);
-            expect(await content.balanceOf(playerAddress.address, 2)).to.equal(25);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(0);
+            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(25);
         });
         
         it('Invalid burns', async () => {
-            const signature = await sign(playerAddress.address, [1], [10], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1], [10], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0], [10], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0], [10], 1, craftingSystemAddress.address, signature];
             await content.connect(playerAddress).mintBatch(mintData);
     
-            var burnData = [playerAddress.address, [1], [5]];
+            var burnData = [playerAddress.address, [0], [5]];
 
             await expect(content.connect(lootboxSystemAddress).mintBatch(burnData)).to.be.reverted;
             await expect(content.connect(player2Address).mintBatch(burnData)).to.be.reverted;
 
             // player tries to burn more assets than they have
-            var burnData2 = [playerAddress.address, [1], [11]];
+            var burnData2 = [playerAddress.address, [0], [11]];
             await expect (content.connect(playerAddress).burnBatch(burnData2)).to.be.reverted;
 
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(10);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(10);
         });
     });
 
     describe("Transfer", () => {
         it('Transfer Assets', async () => {
-            const signature = await sign(playerAddress.address, [1], [10], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1], [10], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0], [10], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0], [10], 1, craftingSystemAddress.address, signature];
             await content.connect(playerAddress).mintBatch(mintData);
     
-            await expect(content.connect(playerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 1, 1, 0))
+            await expect(content.connect(playerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 0, 1, 0))
                 .to.emit(content, 'TransferSingle');
         });
     
         it('Invalid Transfer Assets', async () => {
-            const signature = await sign(playerAddress.address, [1], [10], 1, craftingSystemAddress.address, content.address);
-            var mintData = [playerAddress.address, [1], [10], 1, craftingSystemAddress.address, signature];
+            const signature = await sign(playerAddress.address, [0], [10], 1, craftingSystemAddress.address, content.address);
+            var mintData = [playerAddress.address, [0], [10], 1, craftingSystemAddress.address, signature];
             await content.connect(playerAddress).mintBatch(mintData);
             
             // insufficient balance
-            await expect(content.connect(playerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 1, 15, 0)).to.be.reverted;
-            await expect(content.connect(player2Address).safeTransferFrom(playerAddress.address, player2Address.address, 1, 1, 0)).to.be.reverted;
-            await expect(content.connect(deployerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 1, 1, 0)).to.be.reverted;
+            await expect(content.connect(playerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 0, 15, 0)).to.be.reverted;
+            await expect(content.connect(player2Address).safeTransferFrom(playerAddress.address, player2Address.address, 0, 1, 0)).to.be.reverted;
+            await expect(content.connect(deployerAddress).safeTransferFrom(playerAddress.address, player2Address.address, 0, 1, 0)).to.be.reverted;
         });
     });
 });

--- a/test/content/ContentTests.js
+++ b/test/content/ContentTests.js
@@ -173,7 +173,7 @@ describe('Content Contract Tests', () => {
             expect(await content.totalSupply(1)).to.equal(30);
             expect(await content.balanceOf(playerAddress.address, 1)).to.equal(30);
 
-            const signature2 = await sign(playerAddress.address, [21], [90], 2, craftingSystemAddress.address, content.address);
+            const signature2 = await sign(playerAddress.address, [1], [90], 2, craftingSystemAddress.address, content.address);
             var invalidSupplyData = [playerAddress.address, [1], [90], 2, craftingSystemAddress.address, signature2];
             
             await expect(content.connect(playerAddress).mintBatch(invalidSupplyData)).to.be.reverted;
@@ -211,8 +211,8 @@ describe('Content Contract Tests', () => {
     
             var burnData = [playerAddress.address, [0], [5]];
 
-            await expect(content.connect(lootboxSystemAddress).mintBatch(burnData)).to.be.reverted;
-            await expect(content.connect(player2Address).mintBatch(burnData)).to.be.reverted;
+            await expect(content.connect(lootboxSystemAddress).burnBatch(burnData)).to.be.reverted;
+            await expect(content.connect(player2Address).burnBatch(burnData)).to.be.reverted;
 
             // player tries to burn more assets than they have
             var burnData2 = [playerAddress.address, [0], [11]];

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -60,8 +60,8 @@ describe('Exchange Contract', () => {
     // Asset 1 has 200 basis points towards creator 1
     // Asset 2 has 200 basis points towards creator 1, 100 basis points towards creator 2
     var asset = [
-      ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, creator1Address.address, 20000],
-      ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
+      ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, creator1Address.address, 20000],
+      ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 100, ethers.constants.AddressZero, 0],
     ];
 
     await contentManager.addAssetBatch(asset);

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -60,17 +60,17 @@ describe('Exchange Contract', () => {
     // Asset 1 has 200 basis points towards creator 1
     // Asset 2 has 200 basis points towards creator 1, 100 basis points towards creator 2
     var asset = [
-      [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, creator1Address.address, 20000],
-      [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
+      ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, creator1Address.address, 20000],
+      ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
     ];
 
     await contentManager.addAssetBatch(asset);
 
     // Mint an asset
-    var mintData = [playerAddress.address, [1, 2], [10, 1], 0, ethers.constants.AddressZero, []];
+    var mintData = [playerAddress.address, [0, 1], [10, 1], 0, ethers.constants.AddressZero, []];
     await content.connect(deployerAddress).mintBatch(mintData);
 
-    mintData = [player2Address.address, [1, 2], [10, 10], 0, ethers.constants.AddressZero, []];
+    mintData = [player2Address.address, [0, 1], [10, 10], 0, ethers.constants.AddressZero, []];
     await content.connect(deployerAddress).mintBatch(mintData);
   }
 
@@ -142,7 +142,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         player2Address.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -172,7 +172,7 @@ describe('Exchange Contract', () => {
       await ContentContractSetup();
       await RawrTokenSetup();
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -195,7 +195,7 @@ describe('Exchange Contract', () => {
 
       var exchangeNftEscrow = await NftEscrow.attach(nftEscrowAddr);
       expect(await exchangeNftEscrow.escrowedAmounts(orderId)).to.equal(1);
-      expect(await content.balanceOf(exchangeNftEscrow.address, 1)).to.equal(1);
+      expect(await content.balanceOf(exchangeNftEscrow.address, 0)).to.equal(1);
     });
 
     it('Delete Orders', async () => {
@@ -203,7 +203,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         player2Address.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -235,7 +235,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -270,7 +270,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -292,7 +292,7 @@ describe('Exchange Contract', () => {
         .to.emit(exchange, 'OrdersFilled');
 
       // Player 2 originally has 10, but after buying 1 more, he should have 11
-      expect(await content.balanceOf(player2Address.address, 1)).to.equal(11);
+      expect(await content.balanceOf(player2Address.address, 0)).to.equal(11);
       expect(await feesEscrow.totalFees(rawrToken.address)).to.equal(ethers.BigNumber.from(3).mul(_1e18));
       expect(await rawrToken.balanceOf(feesEscrow.address)).to.equal(ethers.BigNumber.from(3).mul(_1e18));
     });
@@ -302,7 +302,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(100).mul(_1e18),
@@ -310,7 +310,7 @@ describe('Exchange Contract', () => {
         false
       ];
       var order2Data = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(100).mul(_1e18),
@@ -336,10 +336,10 @@ describe('Exchange Contract', () => {
       // Player 2 buys 4 items from the 2 orders
       expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 4, ethers.BigNumber.from(400).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
-        .withArgs(player2Address.address, [order1Id, order2Id], [2, 2], [content.address, 1], rawrToken.address, 4, ethers.BigNumber.from(400).mul(_1e18));
+        .withArgs(player2Address.address, [order1Id, order2Id], [2, 2], [content.address, 0], rawrToken.address, 4, ethers.BigNumber.from(400).mul(_1e18));
 
       // player 2 should now have 4 assets
-      expect(await content.balanceOf(player2Address.address, 1)).to.equal(14);
+      expect(await content.balanceOf(player2Address.address, 0)).to.equal(14);
 
       // check order data
       order = await exchange.getOrder(order1Id);
@@ -354,7 +354,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(100).mul(_1e18),
@@ -362,7 +362,7 @@ describe('Exchange Contract', () => {
         false
       ];
       var order2Data = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(100).mul(_1e18),
@@ -388,15 +388,15 @@ describe('Exchange Contract', () => {
       // Fill Order 1 first
       expect(await exchange.connect(player2Address).fillSellOrder([order1Id], 2, ethers.BigNumber.from(100).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
-        .withArgs(player2Address.address, [order1Id], [1], [content.address, 1], rawrToken.address, 1, ethers.BigNumber.from(100).mul(_1e18));
+        .withArgs(player2Address.address, [order1Id], [1], [content.address, 0], rawrToken.address, 1, ethers.BigNumber.from(100).mul(_1e18));
 
       // // Player 2 buys 2 items from the 2 orders, ignoring order
       expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 3, ethers.BigNumber.from(300).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
-        .withArgs(player2Address.address, [order1Id, order2Id], [0, 3], [content.address, 1], rawrToken.address, 3, ethers.BigNumber.from(300).mul(_1e18));
+        .withArgs(player2Address.address, [order1Id, order2Id], [0, 3], [content.address, 0], rawrToken.address, 3, ethers.BigNumber.from(300).mul(_1e18));
 
       // player 2 should now have 4 assets
-      expect(await content.balanceOf(player2Address.address, 1)).to.equal(14);
+      expect(await content.balanceOf(player2Address.address, 0)).to.equal(14);
 
       // check order data
       order = await exchange.getOrder(order1Id);
@@ -413,7 +413,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),
@@ -440,7 +440,7 @@ describe('Exchange Contract', () => {
       await exchange.connect(playerAddress).claimOrders([orderId]);
 
       // Player 1 originally has 10, but after buying 1 more, he should have 11
-      expect(await content.balanceOf(playerAddress.address, 1)).to.equal(11);
+      expect(await content.balanceOf(playerAddress.address, 0)).to.equal(11);
     });
 
     it('Claim Creator Royalties', async () => {
@@ -448,7 +448,7 @@ describe('Exchange Contract', () => {
       await RawrTokenSetup();
 
       var orderData = [
-        [content.address, 1],
+        [content.address, 0],
         playerAddress.address,
         rawrToken.address,
         ethers.BigNumber.from(1000).mul(_1e18),

--- a/test/exchange/ExecutionManagerTests.js
+++ b/test/exchange/ExecutionManagerTests.js
@@ -58,17 +58,17 @@ describe('Execution Manager Contract Tests', ()=> {
             
         // Add 2 assets
         var asset = [
-            [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-            [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
+            ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
         ];
 
         await contentManager.addAssetBatch(asset);
         
         // Mint an asset
-        var mintData = [playerAddress.address, [1], [10], 0, ethers.constants.AddressZero, []];
+        var mintData = [playerAddress.address, [0], [10], 0, ethers.constants.AddressZero, []];
         await content.connect(deployerAddress).mintBatch(mintData);
         
-        mintData = [player2Address.address, [2], [5], 0, ethers.constants.AddressZero, []];
+        mintData = [player2Address.address, [1], [5], 0, ethers.constants.AddressZero, []];
         await content.connect(deployerAddress).mintBatch(mintData);
     }
 
@@ -158,7 +158,7 @@ describe('Execution Manager Contract Tests', ()=> {
             var orders = [1];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];
             var amounts = [1];
-            var asset = [content.address, 2];
+            var asset = [content.address, 1];
 
             await content.connect(player2Address).setApprovalForAll(nftEscrow.address, true);
             await executionManager.executeBuyOrder(player2Address.address, orders, paymentPerOrder, amounts, asset);
@@ -168,7 +168,7 @@ describe('Execution Manager Contract Tests', ()=> {
 
             var assetData = await nftEscrow.escrowedAsset(1);
             expect(assetData.contentAddress).to.equal(content.address);
-            expect(assetData.tokenId).to.equal(2);
+            expect(assetData.tokenId).to.equal(1);
         });
         
         it('Invalid Execute Buy Order', async () => {
@@ -182,7 +182,7 @@ describe('Execution Manager Contract Tests', ()=> {
             var orders = [1, 2];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];
             var amounts = [1];
-            var asset = [content.address, 1];
+            var asset = [content.address, 2];
 
             await content.connect(player2Address).setApprovalForAll(nftEscrow.address, true);
             await expect(executionManager.executeBuyOrder(player2Address.address, orders, paymentPerOrder, amounts, asset)).to.be.reverted;
@@ -200,7 +200,7 @@ describe('Execution Manager Contract Tests', ()=> {
             await ContentContractSetup();
     
             await content.connect(playerAddress).setApprovalForAll(nftEscrow.address, true);
-            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 1], 2);
+            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 0], 2);
             
             expect(await nftEscrow.escrowedAmounts(1)).to.equal(2);
         });
@@ -211,7 +211,7 @@ describe('Execution Manager Contract Tests', ()=> {
             await ContentContractSetup();
     
             await content.connect(playerAddress).setApprovalForAll(nftEscrow.address, true);
-            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 1], 2);
+            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 0], 2);
     
             var orders = [1];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];
@@ -229,7 +229,7 @@ describe('Execution Manager Contract Tests', ()=> {
             await ContentContractSetup();
     
             await content.connect(playerAddress).setApprovalForAll(nftEscrow.address, true);
-            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 1], 2);
+            await executionManager.placeSellOrder(1, playerAddress.address, [content.address, 0], 2);
     
             var orders = [1, 2];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];
@@ -249,7 +249,7 @@ describe('Execution Manager Contract Tests', ()=> {
             await ContentContractSetup();
     
             var sellOrderData = [ 
-                [content.address, 1],
+                [content.address, 0],
                 playerAddress.address,
                 rawrToken.address,
                 ethers.BigNumber.from(1000).mul(_1e18),
@@ -260,13 +260,13 @@ describe('Execution Manager Contract Tests', ()=> {
             var id = await orderbook.ordersLength();
             await orderbook.placeOrder(sellOrderData);
             await content.connect(playerAddress).setApprovalForAll(nftEscrow.address, true);
-            await executionManager.placeSellOrder(id, playerAddress.address, [content.address, 1], 2);
+            await executionManager.placeSellOrder(id, playerAddress.address, [content.address, 0], 2);
             await executionManager.cancelOrders([id]);
     
             expect(await nftEscrow.escrowedAmounts(id)).to.equal(0);
             
             var buyOrderData = [ 
-                [content.address, 2],
+                [content.address, 1],
                 playerAddress.address,
                 rawrToken.address,
                 web3.utils.toWei('1000', 'ether'),
@@ -291,7 +291,7 @@ describe('Execution Manager Contract Tests', ()=> {
     
             // Create and fill a buy order
             var buyOrderData = [ 
-                [content.address, 2],
+                [content.address, 1],
                 playerAddress.address,
                 rawrToken.address,
                 ethers.BigNumber.from(1000).mul(_1e18),
@@ -308,7 +308,7 @@ describe('Execution Manager Contract Tests', ()=> {
             var orders = [orderId];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];
             var amounts = [2];
-            var asset = [content.address, 2];
+            var asset = [content.address, 1];
     
             await content.connect(player2Address).setApprovalForAll(nftEscrow.address, true);
             await executionManager.executeBuyOrder(player2Address.address, orders, paymentPerOrder, amounts, asset);
@@ -326,7 +326,7 @@ describe('Execution Manager Contract Tests', ()=> {
 
             // Create and fill a sell order
             var sellOrderData = [ 
-                [content.address, 1],
+                [content.address, 0],
                 playerAddress.address,
                 rawrToken.address,
                 ethers.BigNumber.from(1000).mul(_1e18),
@@ -338,7 +338,7 @@ describe('Execution Manager Contract Tests', ()=> {
             await orderbook.placeOrder(sellOrderData);
 
             await content.connect(playerAddress).setApprovalForAll(nftEscrow.address, true);
-            await executionManager.placeSellOrder(id, playerAddress.address, [content.address, 1], 2);
+            await executionManager.placeSellOrder(id, playerAddress.address, [content.address, 0], 2);
 
             var orders = [id];
             var paymentPerOrder = [ethers.BigNumber.from(1000).mul(_1e18)];

--- a/test/exchange/NftEscrowTests.js
+++ b/test/exchange/NftEscrowTests.js
@@ -47,18 +47,18 @@ describe('NFT Escrow Contract', () => {
         contentManager = await ContentManager.attach(deployedContracts[0].args.contentManager);
         
         var asset = [
-            [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-            [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
+            ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 100, ethers.constants.AddressZero, 0]
         ];
 
         // Add 2 assets
         await contentManager.addAssetBatch(asset);
 
         // Mint an assets
-        var mintData = [playerAddress.address, [1, 2], [10, 1], 0, ethers.constants.AddressZero, []];
+        var mintData = [playerAddress.address, [0, 1], [10, 1], 0, ethers.constants.AddressZero, []];
         await content.connect(deployerAddress).mintBatch(mintData);
 
-        assetData = [content.address, 1];
+        assetData = [content.address, 0];
 
         // approve player
         await content.connect(playerAddress).setApprovalForAll(escrow.address, true);
@@ -114,8 +114,8 @@ describe('NFT Escrow Contract', () => {
             await escrow.connect(executionManagerAddress).deposit(1, playerAddress.address, 1, assetData);
     
             expect(await escrow.escrowedAmounts(1)).to.equal(1);
-            expect(await content.balanceOf(escrow.address, 1)).to.equal(1);
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(9);
+            expect(await content.balanceOf(escrow.address, 0)).to.equal(1);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(9);
             
             var internalAssetData = await escrow.escrowedAsset(1);
             expect(internalAssetData[0]).to.equal(assetData[0]);
@@ -129,8 +129,8 @@ describe('NFT Escrow Contract', () => {
             await escrow.connect(executionManagerAddress).withdraw(1, playerAddress.address, 1);
     
             expect(await escrow.escrowedAmounts(1)).to.equal(0);
-            expect(await content.balanceOf(escrow.address, 1)).to.equal(0);
-            expect(await content.balanceOf(playerAddress.address, 1)).to.equal(10);
+            expect(await content.balanceOf(escrow.address, 0)).to.equal(0);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(10);
         });
     
         it('Invalid Withdraws', async () => {

--- a/test/exchange/RoyaltyManagerTests.js
+++ b/test/exchange/RoyaltyManagerTests.js
@@ -52,8 +52,8 @@ describe('Royalty Manager Contract', ()=> {
             
         // Add 2 assets
         var asset = [
-            [1, "arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", ethers.constants.MaxUint256, deployerAddress.address, 20000],
-            [2, "arweave.net/tx/public-uri-2", "arweave.net/tx/private-uri-2", 100, ethers.constants.AddressZero, 0],
+            ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", ethers.constants.MaxUint256, deployerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 100, ethers.constants.AddressZero, 0]
         ];
 
         await contentManager.addAssetBatch(asset);
@@ -154,7 +154,7 @@ describe('Royalty Manager Contract', ()=> {
             await RawrTokenSetup();
             await RoyaltyManagerSetup();
             
-            var assetData = [content.address, 2];
+            var assetData = [content.address, 1];
             var results = await royaltyManager.payableRoyalties(assetData, ethers.BigNumber.from(10000).mul(_1e18));
 
             expect(results.receiver).to.equal(creatorAddress.address);


### PR DESCRIPTION
#43 

In this PR, we update the AddAssetBatch() to automatically generate an asset id for the assets being created. This optimizes a few things:
- makes the input parameter for AddAssetBatch() smaller by removing uint256 id
- Removes tokenid exists check in AddAssetBatch() making the transaction slightly cheaper
- removes ids[] array which stores less data in the content storage contract

Other:
- Update unit tests
- Update Content contract TokenExists()
- Update contract interface ids

Corresponding Subgraph PR: https://github.com/Rawrshak/Subgraphs/pull/10