### PR TITLE
[BugFix] ClaimOrders fix incorrect order state check

### DIFF
--- a/contracts/exchange/Orderbook.sol
+++ b/contracts/exchange/Orderbook.sol
@@ -74,7 +74,7 @@ contract Orderbook is IOrderbook, ManagerBase {
         for (uint256 i = 0; i < _orderIds.length; ++i) {
             // If the state is Partially Filled, we don't set the order state as claimed. Claimed state 
             // only occurs for when the order is completely filled and the order owner claims.
-            if (orders[i].state == LibOrder.OrderState.FILLED) {
+            if (orders[_orderIds[i]].state == LibOrder.OrderState.FILLED) {
                 orders[_orderIds[i]].state = LibOrder.OrderState.CLAIMED;
             }
         }

--- a/test/exchange/OrderbookTests.js
+++ b/test/exchange/OrderbookTests.js
@@ -330,6 +330,33 @@ describe('Orderbook Contract tests', () => {
       expect(storedOrder.state).is.equal(4); // State.CANCELLED
     });
 
+    it('Cancel Order after Claim Orders', async () => {
+      id = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData1);
+      id3 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData3);
+  
+      await orderbook.fillOrders([id, id3], [5, 1]);
+  
+      storedOrder = await orderbook.getOrder(id);
+      expect(storedOrder.amountFilled).is.equal(5);
+      expect(storedOrder.state).is.equal(2); // State.FILLED
+  
+      storedOrder = await orderbook.getOrder(id3);
+      expect(storedOrder.amountFilled).is.equal(1);
+      expect(storedOrder.state).is.equal(1); // State.PARTIALLY_FILLED
+
+      // Claim orders
+      await orderbook.claimOrders([id3]);
+      storedOrder = await orderbook.getOrder(id3);
+      expect(storedOrder.state).is.equal(1); // State.PARTIALLY_FILLED
+
+      // Cancel Order 3
+      await orderbook.cancelOrders([id3]);
+      storedOrder = await orderbook.getOrder(id3);
+      expect(storedOrder.state).is.equal(4); // State.CANCELLED
+    });
+    
     it('Invalid Operations tests', async () => {
       // var id3 = await orderbook.getId(orderData3);
       id = await orderbook.ordersLength();


### PR DESCRIPTION
The Claim Order incorrectly checks the state of the i-th order instead of the id of the order being passed into the function.

This is causing an incorrect state to be set for the order being passed in IF the i-th order is already set to Filled. 

The result is orphaned orders that cannot be filled anymore. Assets are stuck in escrow. 

Some orders will be left orphaned during Alpha. 

We should add a "rescue order" function later.