### PR TITLE
update royalty and exchange fees cap

### DIFF
--- a/contracts/Content/HasRoyalty.sol
+++ b/contracts/Content/HasRoyalty.sol
@@ -47,7 +47,7 @@ abstract contract HasRoyalty is ContentSubsystemBase {
     function _setTokenRoyalty(uint256 _tokenId, address _receiver, uint24 _rate) internal {
         // _receiver can be address(0) and _rate can be 0. It indicates to use the contract
         // rates
-        require(_rate <= 1e6, "Invalid Fee Rate");
+        require(_rate <= 2e5, "Invalid Fee Rate");
         tokenRoyalty[_tokenId].receiver = _receiver;
         tokenRoyalty[_tokenId].rate = _rate;
         emit TokenRoyaltyUpdated(_parent(), _tokenId, _receiver, _rate);

--- a/contracts/exchange/RoyaltyManager.sol
+++ b/contracts/exchange/RoyaltyManager.sol
@@ -106,12 +106,7 @@ contract RoyaltyManager is IRoyaltyManager, ManagerBase {
 
         if (_asset.contentAddress.supportsInterface(type(IERC2981Upgradeable).interfaceId)) {
             (receiver, royaltyFee) = IERC2981Upgradeable(_asset.contentAddress).royaltyInfo(_asset.tokenId, _total);
-            if (remaining >= royaltyFee) {
-                remaining -= royaltyFee;
-            } else {
-                royaltyFee = remaining;
-                remaining = 0;
-            }
+            remaining -= royaltyFee;
         }
         
         // If contract doesn't support the NFT royalty standard or IContent interface is not supported, ignore royalties

--- a/contracts/exchange/RoyaltyManager.sol
+++ b/contracts/exchange/RoyaltyManager.sol
@@ -106,7 +106,12 @@ contract RoyaltyManager is IRoyaltyManager, ManagerBase {
 
         if (_asset.contentAddress.supportsInterface(type(IERC2981Upgradeable).interfaceId)) {
             (receiver, royaltyFee) = IERC2981Upgradeable(_asset.contentAddress).royaltyInfo(_asset.tokenId, _total);
-            remaining -= royaltyFee;
+            if (remaining >= royaltyFee) {
+                remaining -= royaltyFee;
+            } else {
+                royaltyFee = remaining;
+                remaining = 0;
+            }
         }
         
         // If contract doesn't support the NFT royalty standard or IContent interface is not supported, ignore royalties

--- a/contracts/libraries/LibRoyalty.sol
+++ b/contracts/libraries/LibRoyalty.sol
@@ -11,6 +11,6 @@ library LibRoyalty {
     function validateFee(address _receiver, uint24 _rate) internal pure {
         // Note: _rate can be 0; This signifies no royalty
         require(_receiver != address(0), "Invalid Account Address");
-        require(_rate <= 1e6, "Invalid Fee Rate");
+        require(_rate <= 2e5, "Invalid Fee Rate");
     }
 }

--- a/contracts/staking/ExchangeFeesEscrow.sol
+++ b/contracts/staking/ExchangeFeesEscrow.sol
@@ -50,7 +50,7 @@ contract ExchangeFeesEscrow is IExchangeFeesEscrow, EscrowBase {
     }
  
     function setRate(uint24 _rate) public override onlyRole(MANAGER_ROLE) {
-        require(_rate > 0 && _rate <= 1e6, "Invalid rate");
+        require(_rate > 0 && _rate <= 50000, "Invalid rate");
         require(_staking().totalStakedTokens() > 0, "No staked amount");
 
         // We cannot set the rate unless there are already tokens being staked

--- a/contracts/staking/ExchangeFeesEscrow.sol
+++ b/contracts/staking/ExchangeFeesEscrow.sol
@@ -50,7 +50,7 @@ contract ExchangeFeesEscrow is IExchangeFeesEscrow, EscrowBase {
     }
  
     function setRate(uint24 _rate) public override onlyRole(MANAGER_ROLE) {
-        require(_rate > 0 && _rate <= 50000, "Invalid rate");
+        require(_rate > 0 && _rate <= 5e4, "Invalid rate");
         require(_staking().totalStakedTokens() > 0, "No staked amount");
 
         // We cannot set the rate unless there are already tokens being staked

--- a/test/content/ContentStorageTests.js
+++ b/test/content/ContentStorageTests.js
@@ -51,8 +51,8 @@ describe('ContentStorage Contract Tests', () => {
             await expect(contentStorage.connect(playerAddress).updateSupply(0, 50)).to.be.reverted;
             await expect(contentStorage.connect(playerAddress).setPublicUriBatch([[0, ""]])).to.be.reverted;
             await expect(contentStorage.connect(playerAddress).setHiddenUriBatch([[0, ""]])).to.be.reverted;
-            await expect(contentStorage.connect(playerAddress).setContractRoyalty(playerAddress.address, 1000000)).to.be.reverted;
-            await expect(contentStorage.connect(playerAddress).setTokenRoyaltiesBatch([[0, playerAddress.address, 500000]])).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).setContractRoyalty(playerAddress.address, 200000)).to.be.reverted;
+            await expect(contentStorage.connect(playerAddress).setTokenRoyaltiesBatch([[0, playerAddress.address, 50000]])).to.be.reverted;
         });
     });
     
@@ -133,7 +133,7 @@ describe('ContentStorage Contract Tests', () => {
 
         it('Add mutliple assets, one with invalid fee', async () => {
             var asset = [
-                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", 1000, deployerAddress.address, 2000000],
+                ["arweave.net/tx/public-uri-0", "arweave.net/tx/private-uri-0", 1000, deployerAddress.address, 400000],
                 ["arweave.net/tx/public-uri-1", "arweave.net/tx/private-uri-1", 10, deployerAddress.address, 0]
             ];
             await expect(contentStorage.addAssetBatch(asset)).to.be.reverted;

--- a/test/content/HasRoyaltyTests.js
+++ b/test/content/HasRoyaltyTests.js
@@ -51,7 +51,7 @@ describe('HasRoyalty Contract Tests', () => {
         });
         
         it('Contract royalty rate too high', async () => {
-            await expect(testContract.setContractRoyalty(deployerAddress.address, 1000001)).to.be.reverted;
+            await expect(testContract.setContractRoyalty(deployerAddress.address, 200001)).to.be.reverted;
         });
 
         it('Invalid contract royalty receiver address', async () => {
@@ -130,7 +130,7 @@ describe('HasRoyalty Contract Tests', () => {
         });
 
         it('Token royalty rate too high', async () => {
-            var assetRoyalty = [[1, deployerAddress.address, 1000001]];
+            var assetRoyalty = [[1, deployerAddress.address, 200001]];
             await expect(testContract.setTokenRoyaltiesBatch(assetRoyalty)).to.be.reverted;
         });
 

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -406,12 +406,12 @@ describe('Exchange Contract', () => {
       expect(order.amountFilled).to.equal(3);
     });
 
-    it('Edge case royalty rate', async () => {
+    it('Max royalty rate', async () => {
       await ContentContractSetup();
       await RawrTokenSetup();
 
       // set royalty rate to max
-      await contentManager.setTokenRoyaltiesBatch([[0, creator1Address.address, 1000000]]);
+      await contentManager.setTokenRoyaltiesBatch([[0, creator1Address.address, 200000]]);
 
       var orderData = [
         [content.address, 0],
@@ -440,9 +440,10 @@ describe('Exchange Contract', () => {
       expect(await feesEscrow.totalFees(rawrToken.address)).to.equal(ethers.BigNumber.from(3).mul(_1e18));
       expect(await rawrToken.balanceOf(feesEscrow.address)).to.equal(ethers.BigNumber.from(3).mul(_1e18));
 
-      // receiver should claim payment adjusted after platform fee
       await exchange.connect(creator1Address).claimRoyalties();
-      expect(await rawrToken.balanceOf(creator1Address.address)).to.equal(ethers.BigNumber.from(997).mul(_1e18));
+      expect(await rawrToken.balanceOf(creator1Address.address)).to.equal(ethers.BigNumber.from(200).mul(_1e18));
+      await exchange.connect(playerAddress).claimOrders([orderId]);
+      expect(await rawrToken.balanceOf(playerAddress.address)).to.equal(ethers.BigNumber.from(20797).mul(_1e18));
     });
   });
 


### PR DESCRIPTION
In this PR:
- I updated payableRoyalties() in RoyaltyManager.sol, so that the royaltyFee is adjusted if the royalty rate and exchange fees rate exceed 1e6.