### PR TITLE
set royalty cap for unique assets

### DIFF
--- a/contracts/Content/MultipleRoyalties.sol
+++ b/contracts/Content/MultipleRoyalties.sol
@@ -56,7 +56,7 @@ abstract contract MultipleRoyalties{
     }
 
     /**
-    * @dev Verifies whether the sum of the royalties exceed 1e6 and whether the number of royalties and receivers match
+    * @dev Verifies whether the sum of the royalties exceed 2e5 and whether the number of royalties and receivers match
     * @param _royaltyReceivers addresses to receive the royalties
     * @param _royaltyRates royalty fee percentages
     * @param _originalRoyaltyRate royalty rate of the original item
@@ -69,7 +69,7 @@ abstract contract MultipleRoyalties{
         for (uint256 i = 0; i < _royaltyReceivers.length; ++i) {
             sum += _royaltyRates[i];
         }
-        return (sum <= 1e6);
+        return (sum <= 2e5);
     }
 
     uint256[50] private __gap;

--- a/contracts/Content/UniqueContent.sol
+++ b/contracts/Content/UniqueContent.sol
@@ -152,14 +152,14 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
                 royaltyAmounts[i + 1] = _salePrice * _rates[i] / 1e6;
             }
         } else {
-            // if the total royalties exceed 1e6, split the remainder proportionally to the remaining receivers
+            // if the total royalties exceed 2e5, split the remainder proportionally to the remaining receivers
             uint256 sum;
             for (uint256 i = 0; i < length; ++i) {
                 sum += _rates[i];
             }
             for (uint256 i = 0; i < length; ++i) {
                 receivers[i + 1] = _receivers[i];
-                royaltyAmounts[i + 1] = (_salePrice * _rates[i] / 1e6) * (1e6 - _originalRoyaltyAmount) / sum;
+                royaltyAmounts[i + 1] = (_salePrice * _rates[i] / 1e6) * (2e5 - _originalRoyaltyRate) / sum;
             }
         }
     }

--- a/test/content/MultipleRoyaltiesTests.js
+++ b/test/content/MultipleRoyaltiesTests.js
@@ -45,7 +45,7 @@ describe('Multiple Royalties Contract Tests', () => {
         it('Invalid royalties', async () => {
             var originalRoyalty = 7500;
             var receivers = [creatorAddress.address, creatorAltAddress.address, receiverAddress.address];
-            var rates1 = [497500, 495000, 1];
+            var rates1 = [96250, 96250, 1];
             var rates2 = [10000, 30000, 20000, 10000];
             var rates3 = [20000];
 

--- a/test/content/UniqueContentTests.js
+++ b/test/content/UniqueContentTests.js
@@ -135,7 +135,7 @@ describe('Unique Content Contract Tests', () => {
 
         it('Invalid mints', async () => {
             var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [1], false];
-            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [980001], false];
+            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [180001], false];
             var uniqueAssetCreateData3 = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
             var uniqueAssetCreateData4 = [creatorAddress.address, content.address, 1, "arweave.net/tx/unique-uri-1", [], [], false];
 
@@ -344,7 +344,7 @@ describe('Unique Content Contract Tests', () => {
 
         it('Original royalty update pushes total over limit', async () => {
             var receivers = [creatorAddress.address, receiverAddress.address, playerAddress.address];
-            var rates = [300000, 150000, 50000];
+            var rates = [60000, 30000, 10000];
             var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", receivers, rates, false];
 
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
@@ -353,28 +353,28 @@ describe('Unique Content Contract Tests', () => {
             expect(tokenFees.receiver).to.equal(developerAddress.address);
             expect(tokenFees.royaltyAmount).to.equal(20000);
 
-            // original royalty updates pushes total to 100,000 over the limit of 1e6
-            await contentStorage.setTokenRoyaltiesBatch([[0, developerAltAddress.address, 600000]]);
+            // original royalty updates pushes total to 20,000 over the limit of 2e5
+            await contentStorage.setTokenRoyaltiesBatch([[0, developerAltAddress.address, 120000]]);
 
-            var tokenFees2 = await uniqueContent.multipleRoyaltyInfo(0, 1000000);
+            var tokenFees2 = await uniqueContent.multipleRoyaltyInfo(0, 20000);
             expect(tokenFees2[0][0]).to.equal(developerAltAddress.address);
             expect(tokenFees2[0][1]).to.equal(creatorAddress.address);
             expect(tokenFees2[0][2]).to.equal(receiverAddress.address);
             expect(tokenFees2[0][3]).to.equal(playerAddress.address);
-            expect(tokenFees2[1][0]).to.equal(600000);
+            expect(tokenFees2[1][0]).to.equal(2400);
             // remaining royalties have to be split
-            expect(tokenFees2[1][1]).to.equal(240000);
-            expect(tokenFees2[1][2]).to.equal(120000);
-            expect(tokenFees2[1][3]).to.equal(40000);
+            expect(tokenFees2[1][1]).to.equal(960);
+            expect(tokenFees2[1][2]).to.equal(480);
+            expect(tokenFees2[1][3]).to.equal(160);
 
-            await contentStorage.setTokenRoyaltiesBatch([[0, developerAddress.address, 999995]]);
+            await contentStorage.setTokenRoyaltiesBatch([[0, developerAddress.address, 199995]]);
 
             var tokenFees3 = await uniqueContent.multipleRoyaltyInfo(0, 1000000);
             expect(tokenFees3[0][0]).to.equal(developerAddress.address);
             expect(tokenFees3[0][1]).to.equal(creatorAddress.address);
             expect(tokenFees3[0][2]).to.equal(receiverAddress.address);
             expect(tokenFees3[0][3]).to.equal(playerAddress.address);
-            expect(tokenFees3[1][0]).to.equal(999995);
+            expect(tokenFees3[1][0]).to.equal(199995);
             expect(tokenFees3[1][1]).to.equal(3);
             expect(tokenFees3[1][2]).to.equal(1);
             expect(tokenFees3[1][3]).to.equal(0);
@@ -385,7 +385,7 @@ describe('Unique Content Contract Tests', () => {
 
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             var receivers = [developerAltAddress.address, creatorAddress.address, receiverAddress.address];
-            var invalidRates1 = [500000, 500000, 1];
+            var invalidRates1 = [90000, 90000, 1];
             var invalidRates2 = [10000, 20000];
             var validRates = [10000, 20000, 30000];
 


### PR DESCRIPTION
In this PR:
- I updated the royalty cap of unique assets to a rate of 2e5, and updated the corresponding test contract to reflect this