### PR TITLE
Content Contract and storage optimizations

### DIFF
--- a/contracts/Content/Content.sol
+++ b/contracts/Content/Content.sol
@@ -104,8 +104,7 @@ contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165Sto
     * @param _tokenId uint256 ID of token to query
     */
     function uri(uint256 _tokenId) public view override returns (string memory) {
-        uint256 version = contentStorage.getLatestUriVersion(_tokenId, true);
-        return this.uri(_tokenId, version);
+        return contentStorage.uri(_tokenId, type(uint256).max);
     }
 
     /**
@@ -176,7 +175,7 @@ contract Content is IContent, IERC2981Upgradeable, ERC1155Upgradeable, ERC165Sto
     }
 
     function _tokenExists(uint256 _tokenId) internal view returns(bool) {
-        return _tokenId < contentStorage.assetCounter();
+        return contentStorage.exists(_tokenId);
     }
 
     function _updateSupply(uint256 _tokenId, uint256 _newSupply) internal {

--- a/contracts/Content/ContentStorage.sol
+++ b/contracts/Content/ContentStorage.sol
@@ -21,7 +21,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     /***************** Stored Variables *****************/
     mapping(uint256 => uint256) public override maxSupply;
     mapping(uint256 => uint256) public override supply;
-    uint256 public override assetCounter;
+    uint256 private assetCounter;
 
     /******************** Public API ********************/
     function initialize(
@@ -41,7 +41,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
         _registerInterface(type(IContentStorage).interfaceId);
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     }
-     
+
     /**
     * @dev assigns the address of contentParent and transfers role of DEFAULT_ADMIN_ROLE to the _contentParent parameter
     * @param _contentParent address to be granted roles
@@ -183,6 +183,10 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControlUpgradeable, ERC165StorageUpgradeable) returns (bool) {
         return super.supportsInterface(interfaceId);
+    }
+
+    function exists(uint256 _tokenId) external view override returns (bool) {
+        return _tokenId < assetCounter;
     }
 
     uint256[50] private __gap;

--- a/contracts/Content/interfaces/IContentStorage.sol
+++ b/contracts/Content/interfaces/IContentStorage.sol
@@ -11,7 +11,7 @@ interface IContentStorage is IContractUri {
     event AssetsAdded(address indexed parent, uint256[] tokenIds, LibAsset.CreateData[] assets);
 
     /******** View Functions ********/
-    function assetCounter() external view returns (uint256);
+    function exists(uint256 _tokenId) external view returns (bool);
 
     function supply(uint256 _tokenId) external view returns (uint256);
 

--- a/test/content/ContentStorageTests.js
+++ b/test/content/ContentStorageTests.js
@@ -25,7 +25,7 @@ describe('ContentStorage Contract Tests', () => {
         
         it('Check ContentStorage Contract Interfaces', async () => {
             // IContentStorage Interface
-            expect(await contentStorage.supportsInterface("0xbc04328a")).to.equal(true);
+            expect(await contentStorage.supportsInterface("0xb8c03b75")).to.equal(true);
 
             // IContentSubsystemBase Interface
             expect(await contentStorage.supportsInterface("0x7460af1d")).to.equal(true);
@@ -85,8 +85,6 @@ describe('ContentStorage Contract Tests', () => {
             await expect(results)
                 .to.emit(contentStorage, 'AssetsAdded');
             
-            expect(await contentStorage.assetCounter())
-                .to.equal(1);
             expect(await contentStorage.supply(0))
                 .to.equal(0);
             expect(await contentStorage.maxSupply(0))
@@ -123,8 +121,6 @@ describe('ContentStorage Contract Tests', () => {
             await expect(results)
                 .to.emit(contentStorage, 'AssetsAdded');
             
-            expect(await contentStorage.assetCounter())
-                .to.equal(2);
             expect(await contentStorage.supply(0))
                 .to.equal(0);
             expect(await contentStorage.maxSupply(1))


### PR DESCRIPTION
In this PR:
- Optimized Content.uri() call to automatically pass in the max uint256 instead of querying for the current version. Underneath, in the HasTokenUri._tokenUri(), it already clamps it to the current version if greater than the current version.
- removed exposing the next token id to be created when an asset is created. Exposing this may be a security issue down the line. Instead, expose an exist() function to determine if a token already exists or not.