### PR TITLE
Add unique content storage

### DIFF
--- a/contracts/Content/MultipleRoyalties.sol
+++ b/contracts/Content/MultipleRoyalties.sol
@@ -55,22 +55,5 @@ abstract contract MultipleRoyalties{
         emit TokenRoyaltiesUpdated(_uniqueId, royaltyReceivers[_uniqueId], royaltyRates[_uniqueId]);
     }
 
-    /**
-    * @dev Verifies whether the sum of the royalties exceed 2e5 and whether the number of royalties and receivers match
-    * @param _royaltyReceivers addresses to receive the royalties
-    * @param _royaltyRates royalty fee percentages
-    * @param _originalRoyaltyRate royalty rate of the original item
-    */
-    function _verifyRoyalties(address[] memory _royaltyReceivers, uint24[] memory _royaltyRates, uint256 _originalRoyaltyRate) internal pure returns (bool) {
-        if (_royaltyReceivers.length != _royaltyRates.length) {
-            return false;
-        }
-        uint256 sum = _originalRoyaltyRate;
-        for (uint256 i = 0; i < _royaltyReceivers.length; ++i) {
-            sum += _royaltyRates[i];
-        }
-        return (sum <= 2e5);
-    }
-
     uint256[50] private __gap;
 }

--- a/contracts/Content/MultipleRoyalties.sol
+++ b/contracts/Content/MultipleRoyalties.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.0;
 
 import "../libraries/LibRoyalty.sol";
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpgradeable.sol";
 
-abstract contract MultipleRoyalties{
+abstract contract MultipleRoyalties is ERC165StorageUpgradeable {
 
     /***************** Stored Variables *****************/
     mapping(uint256 => address[]) private royaltyReceivers;
@@ -11,6 +12,10 @@ abstract contract MultipleRoyalties{
 
     /*********************** Events *********************/
     event TokenRoyaltiesUpdated(uint256 indexed uniqueId, address[] royaltyReceivers, uint24[] royaltyRates);
+
+    /******************** Public API ********************/
+    function __MultipleRoyalties_init_unchained() internal onlyInitializing {
+    }
 
     /**************** Internal Functions ****************/
     /**

--- a/contracts/Content/UniqueContent.sol
+++ b/contracts/Content/UniqueContent.sol
@@ -1,66 +1,90 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/utils/ERC1155HolderUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
-import "../libraries/LibAsset.sol";
-import "./MultipleRoyalties.sol";
 import "./interfaces/IMultipleRoyalties.sol";
 import "./interfaces/IUniqueContent.sol";
+import "./interfaces/IUniqueContentStorage.sol";
 import "./interfaces/IContent.sol";
+import "../libraries/LibRoyalty.sol";
 
-contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties, ERC721Upgradeable, ERC1155HolderUpgradeable, IERC2981Upgradeable {
+contract UniqueContent is IUniqueContent, IMultipleRoyalties, ERC721Upgradeable, ERC1155HolderUpgradeable, IERC2981Upgradeable, ERC165StorageUpgradeable {
 
     /***************** Stored Variables *****************/
-    mapping(uint256 => LibAsset.UniqueAsset) uniqueAssetInfo;
+    IUniqueContentStorage uniqueContentStorage;
     uint256 private uniqueIdsCounter;
+
+    using ERC165CheckerUpgradeable for address;
+
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        address _uniqueContentStorage)
+        public initializer
+    {
+        __ERC165_init_unchained();
+        __ERC721_init_unchained(_name, _symbol);
+        __ERC1155Holder_init_unchained();
+        __UniqueContent_init_unchained(_uniqueContentStorage);
+    }
+
+    function __UniqueContent_init_unchained(
+        address _uniqueContentStorage)
+        internal onlyInitializing
+    {
+        _registerInterface(type(IUniqueContent).interfaceId);
+        _registerInterface(type(IERC2981Upgradeable).interfaceId);
+        _registerInterface(type(IMultipleRoyalties).interfaceId);
+
+        uniqueContentStorage = IUniqueContentStorage(_uniqueContentStorage);
+    }
     
     /** Asset Minting
     * @dev If the royalties are valid and if the caller has the original item in their wallet, it takes the original asset, mints the unique asset and updates mappings
     * @param _data LibAsset.UniqueAssetCreateData structure object
     */
     function mint(LibAsset.UniqueAssetCreateData memory _data) external override {
-        require((IERC1155Upgradeable(_data.contentAddress).balanceOf(_msgSender(), _data.tokenId)) >= 1, "You must have the original item in your wallet");
+        require(
+            (_data.contentAddress.supportsInterface(type(IERC2981Upgradeable).interfaceId)) &&
+            (_data.contentAddress.supportsInterface(type(IERC1155Upgradeable).interfaceId)),
+            "Error: content contract not supported"
+        );
+        require((IERC1155Upgradeable(_data.contentAddress).balanceOf(_msgSender(), _data.tokenId)) >= 1, "Error: must have original item");
         (, uint256 _originalRoyaltyRate) = IERC2981Upgradeable(_data.contentAddress).royaltyInfo(_data.tokenId, 1e6);
-        require(_verifyRoyalties(_data.royaltyReceivers, _data.royaltyRates, _originalRoyaltyRate), "The royalties entered are invalid");
+        require(LibRoyalty.verifyRoyalties(_data.royaltyReceivers, _data.royaltyRates, _originalRoyaltyRate), "Error: royalties are invalid");
         // transfers the original asset to be locked in the unique content contract
         IERC1155Upgradeable(_data.contentAddress).safeTransferFrom(_msgSender(), address(this), _data.tokenId, 1, "");
+        uniqueContentStorage.setUniqueAssetInfo(_data, uniqueIdsCounter, _msgSender());
+
         // mint() is a mint and transfer function, if _data.to != msgSender, the caller would be sending the token to someone else
         _mint(_data.to, uniqueIdsCounter);
         
-        uniqueAssetInfo[uniqueIdsCounter].creator = _msgSender();
-        uniqueAssetInfo[uniqueIdsCounter].contentAddress = _data.contentAddress;
-        uniqueAssetInfo[uniqueIdsCounter].tokenId = _data.tokenId;
-        uniqueAssetInfo[uniqueIdsCounter].uniqueAssetUri.push(_data.uniqueAssetUri);
-        uniqueAssetInfo[uniqueIdsCounter].creatorLocked = _data.creatorLocked;
-        _setTokenRoyalties(uniqueIdsCounter, _data.royaltyReceivers, _data.royaltyRates);
-        
-        emit Mint(uniqueIdsCounter, _msgSender(), _data);
-
-        // increment uniqueIdsCounter for next minting process
-        uniqueIdsCounter++;
+        emit Mint(uniqueIdsCounter++, _msgSender(), _data);
     }
 
     /** Asset Burning
     * @dev If the caller is the owner of the token and if the unique asset is not creator locked (or the caller is the creator), it burns the unique asset, returns the original asset, and then deletes the unique asset's token info
     * @param _uniqueId uint256 ID of token to burn
     */
-    function burn(uint256 _uniqueId) external override {
-        require(ownerOf(_uniqueId) == _msgSender(), "You must be the owner of this token to burn it");
-        require(uniqueAssetInfo[_uniqueId].creator == _msgSender() || !uniqueAssetInfo[_uniqueId].creatorLocked, "Creator has disabled the burning of this token");
+     function burn(uint256 _uniqueId) external override {
+        require(ownerOf(_uniqueId) == _msgSender(), "Error: sender not token owner");
+        require(
+            uniqueContentStorage.isCreator(_uniqueId, _msgSender()) ||
+            !uniqueContentStorage.isLocked(_uniqueId),
+            "Error: burning of token disabled"
+        );
         _burn(_uniqueId);
+
+        (uint256 _tokenId, address _contentAddress) = uniqueContentStorage.getAssetData(_uniqueId);
+        uniqueContentStorage.burnUniqueAssetInfo(_uniqueId);
+
         // transfers original asset back to caller
-        IERC1155Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).safeTransferFrom(address(this), _msgSender(), uniqueAssetInfo[_uniqueId].tokenId, 1, "");
-        
-        uniqueAssetInfo[_uniqueId].creator = address(0);
-        uniqueAssetInfo[_uniqueId].contentAddress = address(0);
-        uniqueAssetInfo[_uniqueId].tokenId = 0;
-        uniqueAssetInfo[_uniqueId].version = 0;
-        uniqueAssetInfo[_uniqueId].creatorLocked = false;
-        delete uniqueAssetInfo[_uniqueId].uniqueAssetUri;
-        _deleteTokenRoyalties(_uniqueId);
-        
+        IERC1155Upgradeable(_contentAddress).safeTransferFrom(address(this), _msgSender(), _tokenId, 1, "");
+
         emit Burn(_uniqueId, _msgSender());
     }
 
@@ -69,9 +93,10 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
     * @param _uniqueId uint256 ID of token to query original asset uri of
     * @param _version version number of token to query
     */
-    function originalAssetUri(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
+     function originalAssetUri(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        return IContent(uniqueAssetInfo[_uniqueId].contentAddress).uri(uniqueAssetInfo[_uniqueId].tokenId, _version);
+        (uint256 _tokenId, address _contentAddress) = uniqueContentStorage.getAssetData(_uniqueId);
+        return IContent(_contentAddress).uri(_tokenId, _version);
     }
 
     /**
@@ -81,10 +106,7 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
     */
     function tokenURI(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        if (_version > uniqueAssetInfo[_uniqueId].version) {
-            _version = uniqueAssetInfo[_uniqueId].version;
-        } 
-        return uniqueAssetInfo[_uniqueId].uniqueAssetUri[_version];
+        return uniqueContentStorage.tokenURI(_uniqueId, _version);
     }
 
     /**
@@ -93,22 +115,19 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
     */
     function tokenURI(uint256 _uniqueId) public view override returns (string memory) {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        return uniqueAssetInfo[_uniqueId].uniqueAssetUri[uniqueAssetInfo[_uniqueId].version];
+        return uniqueContentStorage.tokenURI(_uniqueId, type(uint256).max);
     }
 
     /**
     * @dev If the caller is creator and owner of the token, it adds a new version of the unique asset
-    * @param _uniqueId uint256 ID of the token to set its uri
+    * @param _uniqueId uint256 ID of the token that gets a new uri
     * @param _uri string URI to assign
     */
     function setUniqueUri(uint256 _uniqueId, string memory _uri) external override {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        require(uniqueAssetInfo[_uniqueId].creator == _msgSender(), "You are not the creator of this token");
-        require(ownerOf(_uniqueId) == _msgSender(), "You must be the owner of this token to set its uri");
-        uniqueAssetInfo[_uniqueId].uniqueAssetUri.push(_uri);
-        uniqueAssetInfo[_uniqueId].version++;
-
-        emit UniqueUriUpdated(_uniqueId, uniqueAssetInfo[_uniqueId].version);
+        require(ownerOf(_uniqueId) == _msgSender(), "Error: sender not token owner");
+        require(uniqueContentStorage.isCreator(_uniqueId, _msgSender()), "Error: sender not token creator");
+        uniqueContentStorage.setUniqueUri(_uniqueId, _uri);
     }
 
     /**
@@ -118,8 +137,7 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
     */
     function royaltyInfo(uint256 _uniqueId, uint256 _salePrice) external view override returns (address receiver, uint256 royaltyAmount){
         require(_exists(_uniqueId), "Unique Id does not exist");
-        // calls royaltyInfo() in the original asset's contract
-        (receiver, royaltyAmount) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, _salePrice);
+        (receiver, royaltyAmount) = uniqueContentStorage.getRoyalty(_uniqueId, _salePrice);
     }
 
     /**
@@ -129,39 +147,7 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
     */
     function multipleRoyaltyInfo(uint256 _uniqueId, uint256 _salePrice) external view override returns (address[] memory receivers, uint256[] memory royaltyAmounts) {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        // grabs the original item's royalty info
-        (address _creator, uint256 _originalRoyaltyAmount) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, _salePrice);
-        
-        address[] memory _receivers;
-        uint24[] memory _rates;
-        // grabs the additional royalties set for the unique token and places them in provisional arrays
-        (_receivers, _rates) = _getMultipleRoyalties(_uniqueId);
-        uint256 length = _getTokenRoyaltiesLength(_uniqueId);
-        
-        receivers = new address[](length + 1);
-        royaltyAmounts = new uint256[](length + 1);
-        // adds the original creator address and royalty amount to arrays of receivers and royalty amounts
-        receivers[0] = _creator;
-        royaltyAmounts[0] = _originalRoyaltyAmount;
-
-        (, uint256 _originalRoyaltyRate) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, 1e6);
-        // calculates royaltyAmount for each receiver and adds their address and royalty into the two arrays
-        if (_verifyRoyalties(_receivers, _rates, _originalRoyaltyRate)) {
-            for (uint256 i = 0; i < length; ++i) {
-                receivers[i + 1] = _receivers[i];
-                royaltyAmounts[i + 1] = _salePrice * _rates[i] / 1e6;
-            }
-        } else {
-            // if the total royalties exceed 2e5, split the remainder proportionally to the remaining receivers
-            uint256 sum;
-            for (uint256 i = 0; i < length; ++i) {
-                sum += _rates[i];
-            }
-            for (uint256 i = 0; i < length; ++i) {
-                receivers[i + 1] = _receivers[i];
-                royaltyAmounts[i + 1] = (_salePrice * _rates[i] / 1e6) * (2e5 - _originalRoyaltyRate) / sum;
-            }
-        }
+        (receivers, royaltyAmounts) = uniqueContentStorage.getMultipleRoyalties(_uniqueId, _salePrice);
     }
 
     /**
@@ -172,15 +158,12 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, MultipleRoyalties,
      */
     function setTokenRoyalties(uint256 _uniqueId, address[] memory _royaltyReceivers, uint24[] memory _royaltyRates) external override {
         require(_exists(_uniqueId), "Unique Id does not exist");
-        require(uniqueAssetInfo[_uniqueId].creator == _msgSender(), "You are not the creator of this token");
-        (, uint256 _originalRoyaltyRate) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, 1e6);
-        require(_verifyRoyalties(_royaltyReceivers, _royaltyRates, _originalRoyaltyRate), "The royalties you have entered are invalid");
-
-        _setTokenRoyalties(_uniqueId, _royaltyReceivers, _royaltyRates);
+        require(uniqueContentStorage.isCreator(_uniqueId, _msgSender()), "Error: sender not token creator");
+        uniqueContentStorage.setTokenRoyalties(_uniqueId, _royaltyReceivers, _royaltyRates);
     }
 
     // Interface support
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Upgradeable, IERC165Upgradeable, ERC1155ReceiverUpgradeable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Upgradeable, IERC165Upgradeable, ERC1155ReceiverUpgradeable, ERC165StorageUpgradeable) returns (bool) {
         return super.supportsInterface(interfaceId);
     }
 

--- a/contracts/Content/UniqueContent.sol
+++ b/contracts/Content/UniqueContent.sol
@@ -14,12 +14,13 @@ import "../libraries/LibRoyalty.sol";
 
 contract UniqueContent is IUniqueContent, IMultipleRoyalties, ERC721Upgradeable, ERC1155HolderUpgradeable, IERC2981Upgradeable, ERC165StorageUpgradeable {
 
+    using ERC165CheckerUpgradeable for address;
+    
     /***************** Stored Variables *****************/
     IUniqueContentStorage uniqueContentStorage;
     uint256 private uniqueIdsCounter;
 
-    using ERC165CheckerUpgradeable for address;
-
+    /******************** Public API ********************/
     function initialize(
         string memory _name,
         string memory _symbol,
@@ -70,7 +71,7 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, ERC721Upgradeable,
     * @dev If the caller is the owner of the token and if the unique asset is not creator locked (or the caller is the creator), it burns the unique asset, returns the original asset, and then deletes the unique asset's token info
     * @param _uniqueId uint256 ID of token to burn
     */
-     function burn(uint256 _uniqueId) external override {
+    function burn(uint256 _uniqueId) external override {
         require(ownerOf(_uniqueId) == _msgSender(), "Error: sender not token owner");
         require(
             uniqueContentStorage.isCreator(_uniqueId, _msgSender()) ||
@@ -93,7 +94,7 @@ contract UniqueContent is IUniqueContent, IMultipleRoyalties, ERC721Upgradeable,
     * @param _uniqueId uint256 ID of token to query original asset uri of
     * @param _version version number of token to query
     */
-     function originalAssetUri(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
+    function originalAssetUri(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
         require(_exists(_uniqueId), "Unique Id does not exist");
         (uint256 _tokenId, address _contentAddress) = uniqueContentStorage.getAssetData(_uniqueId);
         return IContent(_contentAddress).uri(_tokenId, _version);

--- a/contracts/Content/UniqueContentStorage.sol
+++ b/contracts/Content/UniqueContentStorage.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./MultipleRoyalties.sol";
+import "./interfaces/IUniqueContentStorage.sol";
+import "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
+
+contract UniqueContentStorage is IUniqueContentStorage, MultipleRoyalties {
+
+    /***************** Stored Variables *****************/
+    mapping(uint256 => LibAsset.UniqueAsset) uniqueAssetInfo;
+
+    /**
+    * @dev Records the asset info of a newly minted Asset
+    * @param _data LibAsset.UniqueAssetCreateData structure object
+    * @param _uniqueId uint256 ID of token if the new asset
+    * @param _creator the address of who called the mint function
+    */
+    function setUniqueAssetInfo(LibAsset.UniqueAssetCreateData memory _data, uint256 _uniqueId, address _creator) external override {
+        uniqueAssetInfo[_uniqueId].creator = _creator;
+        uniqueAssetInfo[_uniqueId].contentAddress = _data.contentAddress;
+        uniqueAssetInfo[_uniqueId].tokenId = _data.tokenId;
+        uniqueAssetInfo[_uniqueId].uniqueAssetUri.push(_data.uniqueAssetUri);
+        uniqueAssetInfo[_uniqueId].creatorLocked = _data.creatorLocked;
+
+        _setTokenRoyalties(_uniqueId, _data.royaltyReceivers, _data.royaltyRates);
+    }
+
+    /**
+    * @dev Deletes the asset info of a burned token
+    * @param _uniqueId uint256 ID of the token to be burned
+    */
+    function burnUniqueAssetInfo(uint256 _uniqueId) external override {
+        uniqueAssetInfo[_uniqueId].creator = address(0);
+        uniqueAssetInfo[_uniqueId].contentAddress = address(0);
+        uniqueAssetInfo[_uniqueId].tokenId = 0;
+        uniqueAssetInfo[_uniqueId].version = 0;
+        uniqueAssetInfo[_uniqueId].creatorLocked = false;
+        delete uniqueAssetInfo[_uniqueId].uniqueAssetUri;
+
+        _deleteTokenRoyalties(_uniqueId);
+    }
+
+    /**
+    * @dev Returns the unique asset uri of a specific version
+    * @param _uniqueId uint256 ID of token to query
+    * @param _version version number of token to query
+    */
+    function tokenURI(uint256 _uniqueId, uint256 _version) external view override returns (string memory) {
+        if (_version > uniqueAssetInfo[_uniqueId].version) {
+            _version = uniqueAssetInfo[_uniqueId].version;
+        } 
+        return uniqueAssetInfo[_uniqueId].uniqueAssetUri[_version];
+    }
+
+    /**
+    * @dev Records a new version of the unique asset
+    * @param _uniqueId uint256 ID of the token to set its uri
+    * @param _uri string URI to assign
+    */
+    function setUniqueUri(uint256 _uniqueId, string memory _uri) external override {
+        uniqueAssetInfo[_uniqueId].uniqueAssetUri.push(_uri);
+        uniqueAssetInfo[_uniqueId].version++;
+
+        emit UniqueUriUpdated(_uniqueId, uniqueAssetInfo[_uniqueId].version);
+    }
+
+    /**
+    * @dev Returns the original asset's receiver address and royalty amount for a token sold at a certain sales price
+    * @param _uniqueId uint256 ID of token to query
+    * @param _salePrice price the asset is to be purchased for
+    */
+    function getRoyalty(uint256 _uniqueId, uint256 _salePrice) external view override returns (address receiver, uint256 royaltyAmount) {
+        // calls royaltyInfo() in the original asset's contract
+        (receiver, royaltyAmount) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, _salePrice);
+    }
+
+    /**
+    * @dev Returns an array of receiver addresses and calculated royalty amounts for a token sold at a certain sales price
+    * @param _uniqueId uint256 ID of token to query
+    * @param _salePrice price the asset is to be purchased for
+    */
+    function getMultipleRoyalties(uint256 _uniqueId, uint256 _salePrice) external view override returns (address[] memory receivers, uint256[] memory royaltyAmounts) {
+        // grabs the original item's royalty info
+        (address _creator, uint256 _originalRoyaltyAmount) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, _salePrice);
+
+        address[] memory _receivers;
+        uint24[] memory _rates;
+        // grabs the additional royalties set for the unique token and places them in provisional arrays
+        (_receivers, _rates) = _getMultipleRoyalties(_uniqueId);
+        uint256 length = _getTokenRoyaltiesLength(_uniqueId);
+
+        receivers = new address[](length + 1);
+        royaltyAmounts = new uint256[](length + 1);
+        // adds the original creator address and royalty amount to arrays of receivers and royalty amounts
+        receivers[0] = _creator;
+        royaltyAmounts[0] = _originalRoyaltyAmount;
+
+        (, uint256 _originalRoyaltyRate) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, 1e6);
+        // calculates royaltyAmount for each receiver and adds their address and royalty into the two arrays
+        if (LibRoyalty.verifyRoyalties(_receivers, _rates, _originalRoyaltyRate)) {
+            for (uint256 i = 0; i < length; ++i) {
+                receivers[i + 1] = _receivers[i];
+                royaltyAmounts[i + 1] = _salePrice * _rates[i] / 1e6;
+            }
+        } else {
+            // if the total royalties exceed 2e5, split the remainder proportionally to the remaining receivers
+            uint256 sum;
+            for (uint256 i = 0; i < length; ++i) {
+                sum += _rates[i];
+            }
+            for (uint256 i = 0; i < length; ++i) {
+                receivers[i + 1] = _receivers[i];
+                royaltyAmounts[i + 1] = (_salePrice * _rates[i] / 1e6) * (2e5 - _originalRoyaltyRate) / sum;
+            }
+        }
+    }
+
+    /**
+     * @dev If the given royalties are valid, it sets a unique asset's royalties
+     * @param _uniqueId uint256 ID of the unique asset to set the royalties of
+     * @param _royaltyReceivers addresses to receive the royalties
+     * @param _royaltyRates royalty fee percentages
+     */
+    function setTokenRoyalties(uint256 _uniqueId, address[] memory _royaltyReceivers, uint24[] memory _royaltyRates) external override {
+        (, uint256 _originalRoyaltyRate) = IERC2981Upgradeable(uniqueAssetInfo[_uniqueId].contentAddress).royaltyInfo(uniqueAssetInfo[_uniqueId].tokenId, 1e6);
+        require(LibRoyalty.verifyRoyalties(_royaltyReceivers, _royaltyRates, _originalRoyaltyRate), "Error: royalties are invalid");
+
+        _setTokenRoyalties(_uniqueId, _royaltyReceivers, _royaltyRates);
+    }
+
+    /**
+     * @dev Verifies whether the caller is the creator of this token
+     * @param _uniqueId uint256 ID of the token to query
+     * @param _caller address to be vetted
+     */
+    function isCreator(uint256 _uniqueId, address _caller) external view override returns (bool) {
+        return uniqueAssetInfo[_uniqueId].creator == _caller;
+    }
+
+    /**
+     * @dev Verifies whether the unique asset is creator locked
+     * @param _uniqueId uint256 ID of the token to query
+     */
+    function isLocked(uint256 _uniqueId) external view override returns (bool) {
+        return uniqueAssetInfo[_uniqueId].creatorLocked;
+    }
+
+    /**
+     * @dev Returns the original token Id and content address of a unique asset
+     * @param _uniqueId uint256 ID of token to query
+     */
+    function getAssetData(uint256 _uniqueId) external view override returns (uint256 tokenId, address contentAddress) {
+        tokenId = uniqueAssetInfo[_uniqueId].tokenId;
+        contentAddress = uniqueAssetInfo[_uniqueId].contentAddress;
+    }
+
+    uint256[50] private __gap;
+}

--- a/contracts/Content/UniqueContentStorage.sol
+++ b/contracts/Content/UniqueContentStorage.sol
@@ -10,6 +10,17 @@ contract UniqueContentStorage is IUniqueContentStorage, MultipleRoyalties {
     /***************** Stored Variables *****************/
     mapping(uint256 => LibAsset.UniqueAsset) uniqueAssetInfo;
 
+    /******************** Public API ********************/
+    function initialize() public initializer {
+        __ERC165_init_unchained();
+        __MultipleRoyalties_init_unchained();
+        __UniqueContentStorage_init_unchained();
+    }
+
+    function __UniqueContentStorage_init_unchained() internal onlyInitializing {
+        _registerInterface(type(IUniqueContentStorage).interfaceId);
+    }
+
     /**
     * @dev Records the asset info of a newly minted Asset
     * @param _data LibAsset.UniqueAssetCreateData structure object

--- a/contracts/Content/interfaces/IUniqueContent.sol
+++ b/contracts/Content/interfaces/IUniqueContent.sol
@@ -9,8 +9,6 @@ interface IUniqueContent {
 
     event Burn(uint256 indexed uniqueId, address operator);
 
-    event UniqueUriUpdated(uint256 indexed uniqueId, uint256 indexed version);
-
     /******** View Functions ********/
     function originalAssetUri(uint256 _uniqueId, uint256 _version) external view returns(string memory);
 

--- a/contracts/Content/interfaces/IUniqueContentStorage.sol
+++ b/contracts/Content/interfaces/IUniqueContentStorage.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../libraries/LibAsset.sol";
+
+interface IUniqueContentStorage {
+    /*********************** Events *********************/
+    event UniqueUriUpdated(uint256 indexed uniqueId, uint256 indexed version);
+
+    /******** View Functions ********/
+    function tokenURI(uint256 _uniqueId, uint256 _version) external view returns (string memory);
+
+    function getRoyalty(uint256 _uniqueId, uint256 _salePrice) external view returns (address receiver, uint256 royaltyAmount);
+
+    function getMultipleRoyalties(uint256 _uniqueId, uint256 _salePrice) external view returns (address[] memory receivers, uint256[] memory royaltyAmounts);
+
+    function isCreator(uint256 _uniqueId, address _caller) external view returns (bool);
+
+    function isLocked(uint256 _uniqueId) external view returns (bool);
+
+    function getAssetData(uint256 _uniqueId) external view returns (uint256 tokenId, address contentAddress);
+
+    /******** Mutative Functions ********/
+    function setUniqueAssetInfo(LibAsset.UniqueAssetCreateData memory _data, uint256 _uniqueId, address _caller) external;
+
+    function burnUniqueAssetInfo(uint256 _uniqueId) external;
+
+    function setUniqueUri(uint256 _uniqueId, string memory _uri) external;
+
+    function setTokenRoyalties(uint256 _uniqueId, address[] memory _royaltyReceivers, uint24[] memory _royaltyRates) external;
+}

--- a/contracts/libraries/LibRoyalty.sol
+++ b/contracts/libraries/LibRoyalty.sol
@@ -13,4 +13,15 @@ library LibRoyalty {
         require(_receiver != address(0), "Invalid Account Address");
         require(_rate <= 2e5, "Invalid Fee Rate");
     }
+
+    function verifyRoyalties(address[] memory _royaltyReceivers, uint24[] memory _royaltyRates, uint256 _originalRoyaltyRate) internal pure returns (bool) {
+        if (_royaltyReceivers.length != _royaltyRates.length) {
+            return false;
+        }
+        uint256 sum = _originalRoyaltyRate;
+        for (uint256 i = 0; i < _royaltyReceivers.length; ++i) {
+            sum += _royaltyRates[i];
+        }
+        return (sum <= 2e5);
+    }
 }

--- a/contracts/testContracts/content/TestMultipleRoyalties.sol
+++ b/contracts/testContracts/content/TestMultipleRoyalties.sol
@@ -14,7 +14,7 @@ contract TestMultipleRoyalties is MultipleRoyalties {
     }
 
     function verifyRoyalties(address[] memory _royaltyReceivers, uint24[] memory _royaltyRates, uint256 _originalRoyaltyRate) external pure returns (bool) {
-        return _verifyRoyalties(_royaltyReceivers, _royaltyRates, _originalRoyaltyRate);
+        return LibRoyalty.verifyRoyalties(_royaltyReceivers, _royaltyRates, _originalRoyaltyRate);
     }
 
     function deleteTokenRoyalties(uint256 _uniqueId) external {

--- a/test/content/ContentTests.js
+++ b/test/content/ContentTests.js
@@ -94,6 +94,9 @@ describe('Content Contract Tests', () => {
         it("Uri", async () => {
             expect(await content['uri(uint256,uint256)'](0, 0))
                 .to.equal("arweave.net/tx/public-uri-0");
+            
+            expect(await content['uri(uint256)'](0))
+                .to.equal("arweave.net/tx/public-uri-0");
         });
     
         it('Royalty', async () => {

--- a/test/content/UniqueContentStorageTests.js
+++ b/test/content/UniqueContentStorageTests.js
@@ -1,0 +1,200 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const { sign } = require("../mint");
+
+describe('Unique Content Storage Contract Tests', () => {
+    var developerAddress, developerAltAddress, creatorAddress, receiverAddress, playerAddress;
+    var AccessControlManager, ContentStorage, Content, UniqueContentStorage;
+    var content;
+    var contentStorage;
+    var accessControlManager;
+    var asset;
+    var uniqueContentStorage;
+
+    before(async () => {
+        [developerAddress, developerAltAddress, creatorAddress, receiverAddress, playerAddress] = await ethers.getSigners();
+        UniqueContentStorage = await ethers.getContractFactory("UniqueContentStorage");
+        AccessControlManager = await ethers.getContractFactory("AccessControlManager");
+        ContentStorage = await ethers.getContractFactory("ContentStorage");
+        Content = await ethers.getContractFactory("Content");
+        asset = [
+            ["arweave.net/tx/public-uri-0", "", ethers.constants.MaxUint256, developerAddress.address, 20000],
+            ["arweave.net/tx/public-uri-1", "", 100, ethers.constants.AddressZero, 0],
+        ];
+    });
+
+    beforeEach(async () => {
+        accessControlManager = await upgrades.deployProxy(AccessControlManager, []);
+        contentStorage = await upgrades.deployProxy(ContentStorage, [developerAltAddress.address, 12000, "arweave.net/tx-contract-uri"]);
+        content = await upgrades.deployProxy(Content, [contentStorage.address, accessControlManager.address]);
+
+        await contentStorage.grantRole(await contentStorage.DEFAULT_ADMIN_ROLE(), content.address);
+
+        // Set the content contract as the new parent
+        await accessControlManager.setParent(content.address);
+        await contentStorage.addAssetBatch(asset);
+
+        // launch unique content storage contract
+        uniqueContentStorage = await upgrades.deployProxy(UniqueContentStorage);
+    });
+
+    describe("Unique Asset Info", () => {
+        it('Set and Burn info', async () => {            
+            var receivers = [creatorAddress.address, receiverAddress.address];
+            var rates = [15000, 10000];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, true];
+
+            // record info
+            expect(await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address))
+                .to.emit(uniqueContentStorage, "TokenRoyaltiesUpdated")
+                .withArgs(0, [creatorAddress.address, receiverAddress.address], [15000, 10000]);;
+
+            // check whether the info has been recorded
+            var tokenFees = await uniqueContentStorage.getMultipleRoyalties(0, 1000000);
+            expect(tokenFees[0][0]).to.equal(developerAddress.address);
+            expect(tokenFees[0][1]).to.equal(creatorAddress.address);
+            expect(tokenFees[0][2]).to.equal(receiverAddress.address);
+            expect(tokenFees[1][0]).to.equal(20000);
+            expect(tokenFees[1][1]).to.equal(15000);
+            expect(tokenFees[1][2]).to.equal(10000);
+
+            expect(await uniqueContentStorage.isCreator(0, creatorAddress.address)).to.equal(true);
+            assetData = await uniqueContentStorage.getAssetData(0);
+            expect(assetData[0]).to.equal(0);
+            expect(assetData[1]).to.equal(content.address);
+            expect(await uniqueContentStorage.isLocked(0)).to.equal(true);
+            expect(await uniqueContentStorage.tokenURI(0, 100)).to.equal("arweave.net/tx/unique-uri-0");
+
+            // burn info
+            await uniqueContentStorage.burnUniqueAssetInfo(0);
+
+            // check whether the info has been deleted
+            await expect(uniqueContentStorage.getMultipleRoyalties(0, 1000000)).to.be.reverted;
+            expect(await uniqueContentStorage.isCreator(0, creatorAddress.address)).to.equal(false);
+            assetData = await uniqueContentStorage.getAssetData(0);
+            expect(assetData[0]).to.equal(ethers.constants.AddressZero);
+            expect(assetData[1]).to.equal(ethers.constants.AddressZero);
+            expect(await uniqueContentStorage.isLocked(0)).to.equal(false);
+            await expect(uniqueContentStorage.tokenURI(0, 0)).to.be.reverted;
+        });   
+    });
+
+    describe("Uri Tests", () => {
+        it('Update unique asset uri', async () => {
+            var uniqueAssetCreateData = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, playerAddress.address);
+
+            await expect(uniqueContentStorage.connect(playerAddress).setUniqueUri(0,"arweave.net/tx/unique-uri-0v2"))
+                .to.emit(uniqueContentStorage, "UniqueUriUpdated")
+                .withArgs(0, 1);
+
+            expect(await uniqueContentStorage.tokenURI(0, 0)).to.equal("arweave.net/tx/unique-uri-0");
+            expect(await uniqueContentStorage.tokenURI(0, 1)).to.equal("arweave.net/tx/unique-uri-0v2");
+            expect(await uniqueContentStorage.tokenURI(0, 100)).to.equal("arweave.net/tx/unique-uri-0v2");
+        });
+    });
+
+    describe("Royalty Tests", () => {
+        // Note: Original asset 0's royalty receiver is developerAddress and has a rate of 20,000
+        // The content contract's royalty receiver is developerAltAddress and has a rate of 12,000
+        it('Calculate multiple royalty amounts', async () => {
+            var receivers = [creatorAddress.address, receiverAddress.address];
+            var rates = [10000, 5000];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, false];
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
+
+            var tokenFees = await uniqueContentStorage.getMultipleRoyalties(0, 100000);
+            expect(tokenFees[0][0]).to.equal(developerAddress.address);
+            expect(tokenFees[0][1]).to.equal(creatorAddress.address);
+            expect(tokenFees[0][2]).to.equal(receiverAddress.address);
+
+            expect(tokenFees[1][0]).to.equal(2000);
+            expect(tokenFees[1][1]).to.equal(1000);
+            expect(tokenFees[1][2]).to.equal(500);
+        });
+
+        it('Query original item royalty', async () => {
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", [], [], false];
+            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 1, "", [creatorAddress.address], [10000], false];
+
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
+
+            var tokenFees = await uniqueContentStorage.getRoyalty(0, 1000000);
+            expect(tokenFees.receiver).to.equal(developerAddress.address);
+            expect(tokenFees.royaltyAmount).to.equal(20000);
+
+            // a token with no set royalties should return the default contract royalties
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData2, 1, creatorAddress.address);
+
+            tokenFees = await uniqueContentStorage.getRoyalty(1, 1000000);
+            // token royalty from contract royalty
+            expect(tokenFees.receiver).to.equal(developerAltAddress.address);
+            expect(tokenFees.royaltyAmount).to.equal(12000);
+        });
+
+        it('Update original item royalty', async () => {
+            var receivers = [creatorAddress.address, receiverAddress.address];
+            var rates = [10000, 5000];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", receivers, rates, false];
+
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
+
+            var tokenFees = await uniqueContentStorage.getRoyalty(0, 1000000);
+            expect(tokenFees.receiver).to.equal(developerAddress.address);
+            expect(tokenFees.royaltyAmount).to.equal(20000);
+
+            await contentStorage.setTokenRoyaltiesBatch([[0, developerAltAddress.address, 15000]]);
+
+            var tokenFees2 = await uniqueContentStorage.getRoyalty(0, 1000000);
+            expect(tokenFees2.receiver).to.equal(developerAltAddress.address);
+            expect(tokenFees2.royaltyAmount).to.equal(15000);
+
+            var tokenFees = await uniqueContentStorage.getMultipleRoyalties(0, 100000);
+            expect(tokenFees[0][0]).to.equal(developerAltAddress.address);
+            expect(tokenFees[0][1]).to.equal(creatorAddress.address);
+            expect(tokenFees[0][2]).to.equal(receiverAddress.address);
+
+            expect(tokenFees[1][0]).to.equal(1500);
+            expect(tokenFees[1][1]).to.equal(1000);
+            expect(tokenFees[1][2]).to.equal(500);
+        });
+
+        it('Original royalty update pushes total over limit', async () => {
+            var receivers = [creatorAddress.address, receiverAddress.address, playerAddress.address];
+            var rates = [60000, 30000, 10000];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", receivers, rates, false];
+
+            await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
+
+            var tokenFees = await uniqueContentStorage.getRoyalty(0, 1000000);
+            expect(tokenFees.receiver).to.equal(developerAddress.address);
+            expect(tokenFees.royaltyAmount).to.equal(20000);
+
+            // original royalty updates pushes total to 20,000 over the limit of 2e5
+            await contentStorage.setTokenRoyaltiesBatch([[0, developerAltAddress.address, 120000]]);
+
+            var tokenFees2 = await uniqueContentStorage.getMultipleRoyalties(0, 20000);
+            expect(tokenFees2[0][0]).to.equal(developerAltAddress.address);
+            expect(tokenFees2[0][1]).to.equal(creatorAddress.address);
+            expect(tokenFees2[0][2]).to.equal(receiverAddress.address);
+            expect(tokenFees2[0][3]).to.equal(playerAddress.address);
+            expect(tokenFees2[1][0]).to.equal(2400);
+            // remaining royalties have to be split
+            expect(tokenFees2[1][1]).to.equal(960);
+            expect(tokenFees2[1][2]).to.equal(480);
+            expect(tokenFees2[1][3]).to.equal(160);
+
+            await contentStorage.setTokenRoyaltiesBatch([[0, developerAddress.address, 199995]]);
+
+            var tokenFees3 = await uniqueContentStorage.getMultipleRoyalties(0, 1000000);
+            expect(tokenFees3[0][0]).to.equal(developerAddress.address);
+            expect(tokenFees3[0][1]).to.equal(creatorAddress.address);
+            expect(tokenFees3[0][2]).to.equal(receiverAddress.address);
+            expect(tokenFees3[0][3]).to.equal(playerAddress.address);
+            expect(tokenFees3[1][0]).to.equal(199995);
+            expect(tokenFees3[1][1]).to.equal(3);
+            expect(tokenFees3[1][2]).to.equal(1);
+            expect(tokenFees3[1][3]).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
 #67 
In this PR:

-I split UniqueContent.sol into UniqueContent.sol and UniqueContentStorage.sol because the original Unique Content contract began to exceed the contract code size limit.
-I added Unique Content Storage Tests