### PR TITLE
reducing gas costs in content contracts

### DIFF
--- a/contracts/Content/ContentStorage.sol
+++ b/contracts/Content/ContentStorage.sol
@@ -61,26 +61,25 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     */
     function addAssetBatch(LibAsset.CreateData[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256[] memory tokenIds = new uint256[](_assets.length);
+        uint256 counter = assetCounter;
         for (uint256 i = 0; i < _assets.length; ++i) {
-            tokenIds[i] = assetCounter;
-            supply[assetCounter] = 0;
+            tokenIds[i] = counter;
+            supply[counter] = 0;
 
             // If max supply is set to 0, this means there is no mint limit. Set max supply to uint256.max
             if (_assets[i].maxSupply == 0) {
                 _assets[i].maxSupply = type(uint256).max; 
             } 
-            maxSupply[assetCounter] = _assets[i].maxSupply;
+            maxSupply[counter] = _assets[i].maxSupply;
 
-            _setPublicUri(assetCounter, _assets[i].publicDataUri);
-            _setHiddenUri(assetCounter, _assets[i].hiddenDataUri);
+            _setPublicUri(counter, _assets[i].publicDataUri);
+            _setHiddenUri(counter, _assets[i].hiddenDataUri);
             
             // if this specific token has a different royalty fees than the contract
-            _setTokenRoyalty(assetCounter, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
-
             // increment asset counter
-            assetCounter++;
+            _setTokenRoyalty(counter++, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
         }
-
+        assetCounter = counter;
         emit AssetsAdded(_parent(), tokenIds, _assets);
     }
 

--- a/contracts/Content/ContentStorage.sol
+++ b/contracts/Content/ContentStorage.sol
@@ -61,6 +61,7 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
     */
     function addAssetBatch(LibAsset.CreateData[] memory _assets) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256[] memory tokenIds = new uint256[](_assets.length);
+        // add a provisional counter to use in for loop
         uint256 counter = assetCounter;
         for (uint256 i = 0; i < _assets.length; ++i) {
             tokenIds[i] = counter;
@@ -76,9 +77,10 @@ contract ContentStorage is IContentStorage, AccessControlUpgradeable, HasRoyalty
             _setHiddenUri(counter, _assets[i].hiddenDataUri);
             
             // if this specific token has a different royalty fees than the contract
-            // increment asset counter
+            // increment provisional counter
             _setTokenRoyalty(counter++, _assets[i].royaltyReceiver, _assets[i].royaltyRate);
         }
+        // update assetCounter
         assetCounter = counter;
         emit AssetsAdded(_parent(), tokenIds, _assets);
     }

--- a/contracts/libraries/LibAsset.sol
+++ b/contracts/libraries/LibAsset.sol
@@ -52,21 +52,21 @@ library LibAsset {
     struct UniqueAssetCreateData {
         address to;
         address contentAddress;
+        bool creatorLocked;
         uint256 tokenId;
         string uniqueAssetUri;
         address[] royaltyReceivers;
         uint24[] royaltyRates;
-        bool creatorLocked;
     }
 
     struct UniqueAsset {
         address creator;
         address contentAddress;
+        bool creatorLocked;
         uint256 tokenId;
         uint256 version;
         string[] uniqueAssetUri;
-        bool creatorLocked;
-    }
+    }  
 
     function hashMintData(MintData memory _data) internal pure returns (bytes32) {
         return keccak256(abi.encode(

--- a/test/content/UniqueContentStorageTests.js
+++ b/test/content/UniqueContentStorageTests.js
@@ -42,7 +42,7 @@ describe('Unique Content Storage Contract Tests', () => {
         it('Set and Burn info', async () => {            
             var receivers = [creatorAddress.address, receiverAddress.address];
             var rates = [15000, 10000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, true];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, true, 0, "arweave.net/tx/unique-uri-0", receivers, rates];
 
             // record info
             expect(await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address))
@@ -81,7 +81,7 @@ describe('Unique Content Storage Contract Tests', () => {
 
     describe("Uri Tests", () => {
         it('Update unique asset uri', async () => {
-            var uniqueAssetCreateData = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
+            var uniqueAssetCreateData = [playerAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
             await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, playerAddress.address);
 
             await expect(uniqueContentStorage.connect(playerAddress).setUniqueUri(0,"arweave.net/tx/unique-uri-0v2"))
@@ -100,7 +100,7 @@ describe('Unique Content Storage Contract Tests', () => {
         it('Calculate multiple royalty amounts', async () => {
             var receivers = [creatorAddress.address, receiverAddress.address];
             var rates = [10000, 5000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", receivers, rates];
             await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
 
             var tokenFees = await uniqueContentStorage.getMultipleRoyalties(0, 100000);
@@ -114,8 +114,8 @@ describe('Unique Content Storage Contract Tests', () => {
         });
 
         it('Query original item royalty', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", [], [], false];
-            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 1, "", [creatorAddress.address], [10000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "", [], []];
+            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, false, 1, "", [creatorAddress.address], [10000]];
 
             await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
 
@@ -135,7 +135,7 @@ describe('Unique Content Storage Contract Tests', () => {
         it('Update original item royalty', async () => {
             var receivers = [creatorAddress.address, receiverAddress.address];
             var rates = [10000, 5000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", receivers, rates, false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "", receivers, rates];
 
             await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
 
@@ -162,7 +162,7 @@ describe('Unique Content Storage Contract Tests', () => {
         it('Original royalty update pushes total over limit', async () => {
             var receivers = [creatorAddress.address, receiverAddress.address, playerAddress.address];
             var rates = [60000, 30000, 10000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", receivers, rates, false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "", receivers, rates];
 
             await uniqueContentStorage.setUniqueAssetInfo(uniqueAssetCreateData, 0, creatorAddress.address);
 

--- a/test/content/UniqueContentTests.js
+++ b/test/content/UniqueContentTests.js
@@ -61,7 +61,7 @@ describe('Unique Content Contract Tests', () => {
         it('Mint function', async () => {            
             var receivers = [creatorAddress.address, receiverAddress.address];
             var rates = [15000, 10000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, true];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, true, 0, "arweave.net/tx/unique-uri-0", receivers, rates];
 
             expect(await content.balanceOf(creatorAddress.address, 0)).to.equal(2);
 
@@ -91,7 +91,7 @@ describe('Unique Content Contract Tests', () => {
             expect(tokenFees[1][2]).to.equal(10000);
 
             // mint an asset with no royalties
-            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 1, "arweave.net/tx/unique-uri-1", [], [], false];
+            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, false, 1, "arweave.net/tx/unique-uri-1", [], []];
 
             results = await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData2);
             expect(results)
@@ -112,7 +112,7 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Mint to a different address', async () => {
-            var uniqueAssetCreateData = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
+            var uniqueAssetCreateData = [playerAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
             
             expect(await content.balanceOf(creatorAddress.address, 0)).to.equal(2);
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
@@ -132,11 +132,11 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Invalid mints', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [1], false];
-            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [180001], false];
-            var uniqueAssetCreateData3 = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
-            var uniqueAssetCreateData4 = [creatorAddress.address, content.address, 1, "arweave.net/tx/unique-uri-1", [], [], false];
-            var uniqueAssetCreateData5 = [creatorAddress.address, contentStorage.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], [1]];
+            var uniqueAssetCreateData2 = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [180001]];
+            var uniqueAssetCreateData3 = [playerAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
+            var uniqueAssetCreateData4 = [creatorAddress.address, content.address, false, 1, "arweave.net/tx/unique-uri-1", [], []];
+            var uniqueAssetCreateData5 = [creatorAddress.address, contentStorage.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
 
             // invalid royalties
             await expect(uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData)).to.be.reverted;
@@ -153,8 +153,8 @@ describe('Unique Content Contract Tests', () => {
 
     describe("Burn Tokens", () => {
         it('Burn function', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], true];
-            var uniqueAssetCreateData2 = [playerAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, true, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
+            var uniqueAssetCreateData2 = [playerAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
 
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             expect(await uniqueContent.balanceOf(creatorAddress.address)).to.equal(1);
@@ -192,8 +192,8 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Invalid burns', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], false];
-            var lockedAssetData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [], [], true];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [], []];
+            var lockedAssetData = [creatorAddress.address, content.address, true, 0, "arweave.net/tx/unique-uri-0", [], []];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             await uniqueContent.connect(creatorAddress).mint(lockedAssetData);
 
@@ -211,7 +211,7 @@ describe('Unique Content Contract Tests', () => {
 
     describe("Transfer Tokens", () => {
         it('Transfer assets', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
 
             expect(await uniqueContent.balanceOf(creatorAddress.address)).to.equal(1);
@@ -228,7 +228,7 @@ describe('Unique Content Contract Tests', () => {
         });
         
         it('Invalid transfer', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             
             await expect(uniqueContent.connect(playerAddress)["safeTransferFrom(address,address,uint256)"](creatorAddress.address, playerAddress.address, 0)).to.be.reverted;
@@ -237,7 +237,7 @@ describe('Unique Content Contract Tests', () => {
 
     describe("Uri Tests", () => {
         it('Update original asset uri', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
 
             await contentStorage.setPublicUriBatch([[0, "arweave.net/tx/public-uri-0v2"]]);
@@ -248,7 +248,7 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Set unique asset uri', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
 
             await uniqueContent.connect(creatorAddress).setUniqueUri(0,"arweave.net/tx/unique-uri-0v2");
@@ -260,7 +260,7 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Invalid set unique asset uri', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", [creatorAddress.address], [20000]];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             
             await expect(uniqueContent.connect(creatorAddress).setUniqueUri(100, "arweave.net/tx/unique-uri-100")).to.be.reverted;
@@ -284,7 +284,7 @@ describe('Unique Content Contract Tests', () => {
         it('Query royalties', async () => {
             var receivers = [creatorAddress.address, receiverAddress.address];
             var rates = [5000, 5000];
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "arweave.net/tx/unique-uri-0", receivers, rates, false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "arweave.net/tx/unique-uri-0", receivers, rates];
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
 
             var tokenFees = await uniqueContent.royaltyInfo(0, 50000);
@@ -302,7 +302,7 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Set token royalties', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", [], [], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "", [], []];
 
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             
@@ -317,7 +317,7 @@ describe('Unique Content Contract Tests', () => {
         });
 
         it('Invalid set token royalties', async () => {
-            var uniqueAssetCreateData = [creatorAddress.address, content.address, 0, "", [], [], false];
+            var uniqueAssetCreateData = [creatorAddress.address, content.address, false, 0, "", [], []];
 
             await uniqueContent.connect(creatorAddress).mint(uniqueAssetCreateData);
             var receivers = [developerAltAddress.address, creatorAddress.address, receiverAddress.address];


### PR DESCRIPTION
In this PR:
- I rewrote the addAssetBatch function so that it only modifies assetCounter once when adding multiple assets.
- I re-arranged the UniqueAsset and UniqueAssetCreateData struct so that the creatorLocked boolean is packed together with contentAddress in one slot.